### PR TITLE
(feat) Add ability to read SEAMLeSS fields (legacy)

### DIFF
--- a/corgie/data_backends/cvbackend.py
+++ b/corgie/data_backends/cvbackend.py
@@ -250,3 +250,8 @@ class CVMaskLayer(CVLayerBase, layers.MaskLayer):
 class CVSectionValueLayer(CVLayerBase, layers.SectionValueLayer):
     def __init__(self, *kargs, **kwargs):
         super().__init__(*kargs, **kwargs)
+
+@CVDataBackend.register_layer_type_backend("fixed_field")
+class CVSectionValueLayer(CVFieldLayer, layers.FixedFieldLayer):
+    def __init__(self, *kargs, **kwargs):
+        super().__init__(*kargs, **kwargs)

--- a/corgie/data_backends/cvbackend.py
+++ b/corgie/data_backends/cvbackend.py
@@ -239,6 +239,11 @@ class CVFieldLayer(CVLayerBase, layers.FieldLayer):
                     )
         self.backend_dtype = backend_dtype
 
+    def read_backend(self, bcube, mip, transpose=True, timestamp=None):
+        data = super().read_backend(bcube, mip, transpose, timestamp)
+        if self.backend_dtype == 'int16':
+            data = np.float32(data) / 4
+        return data
 
 @CVDataBackend.register_layer_type_backend("mask")
 class CVMaskLayer(CVLayerBase, layers.MaskLayer):

--- a/corgie/layers/__init__.py
+++ b/corgie/layers/__init__.py
@@ -1,8 +1,12 @@
 from corgie.layers.base import get_layer_types, str_to_layer_type
 
 # when adding a new layer type, include it here
-from corgie.layers.volumetric_layers import FieldLayer, ImgLayer, MaskLayer, \
-        SectionValueLayer, SegmentationLayer
+from corgie.layers.volumetric_layers import FieldLayer, \
+                                            ImgLayer, \
+                                            MaskLayer, \
+                                            SectionValueLayer, \
+                                            SegmentationLayer, \
+                                            FixedFieldLayer
 
 # also update the default layer type if you want to
 DEFAULT_LAYER_TYPE = 'img'


### PR DESCRIPTION
Add layer to read fields stored with displacements at a fixed resolution, such as those produced by [SEAMLeSS](https://github.com/seung-lab/SEAMLeSS). This is meant to make previously written fields forward-compatible. It does not provide the ability to write fields into the old format, though.

Also add ability to read fields stored in the legacy int16 fixed-point format of [SEAMLeSS](https://github.com/seung-lab/SEAMLeSS).