### PR TITLE
Uploading Tasks more efficiently

### DIFF
--- a/corgie/cli/merge_render.py
+++ b/corgie/cli/merge_render.py
@@ -41,11 +41,12 @@ class MergeRenderJob(scheduling.Job):
 
     def task_generator(self):
         chunks = self.dst_layer.break_bcube_into_chunks(
-            bcube=self.bcube, chunk_xy=self.chunk_xy, chunk_z=1, mip=self.mip
+            bcube=self.bcube, chunk_xy=self.chunk_xy, chunk_z=1, mip=self.mip,
+            return_generator=True
         )
 
         if "src_img" in self.src_specs[0]:
-            tasks = [
+            tasks = (
                 MergeRenderImageTask(
                     src_layers=self.src_layers,
                     src_specs=self.src_specs,
@@ -55,9 +56,9 @@ class MergeRenderJob(scheduling.Job):
                     bcube=input_chunk,
                 )
                 for input_chunk in chunks
-            ]
+            )
         else:
-            tasks = [
+            tasks = (
                 MergeRenderMaskTask(
                     src_layers=self.src_layers,
                     src_specs=self.src_specs,
@@ -67,7 +68,7 @@ class MergeRenderJob(scheduling.Job):
                     bcube=input_chunk,
                 )
                 for input_chunk in chunks
-            ]
+            )
         corgie_logger.info(
             f"Yielding render tasks for bcube: {self.bcube}, MIP: {self.mip}"
         )

--- a/corgie/cli/render.py
+++ b/corgie/cli/render.py
@@ -64,7 +64,7 @@ class RenderJob(scheduling.Job):
                 return_generator=True,
             )
 
-            tasks = [
+            tasks = (
                 RenderTask(
                     self.src_stack,
                     self.dst_stack,
@@ -79,7 +79,7 @@ class RenderJob(scheduling.Job):
                     seethrough_offset=self.seethrough_offset,
                 )
                 for input_chunk in chunks
-            ]
+            )
             corgie_logger.info(
                 f"Yielding render tasks for bcube: {self.bcube}, MIP: {mip}"
             )


### PR DESCRIPTION
Switched task lists to task generators in a bunch of places. Also found out why merge tasks are so big -- each tasks stores a lot of CloudVolumes. 

NOTE: this requires `mazepa>=0.0.7` to work properly