### PR TITLE
fix(FieldSet): snap translations to full pixel size

### DIFF
--- a/corgie/helpers.py
+++ b/corgie/helpers.py
@@ -41,6 +41,15 @@ class Translation:
 
     def __sub__(self, T):
         return Translation(self.x - T.x, self.y - T.y)
+
+    def __mul__(self, scalar):
+        return Translation(self.x * scalar, self.y * scalar)
+
+    def __floordiv__(self, scalar):
+        return Translation(self.x // scalar, self.y // scalar)
+
+    def __truediv__(self, scalar):
+        return Translation(self.x / scalar, self.y / scalar)
     
     def to_tensor(self, **kwargs):
         return torch.tensor([[[[self.x]],[[self.y]]]], **kwargs)

--- a/corgie/helpers.py
+++ b/corgie/helpers.py
@@ -89,10 +89,6 @@ def percentile_trans_adjuster(field, h=25, l=75, unaligned_img=None):
         if nonzero_field.sum() == 0:
             result = Translation(0, 0)
         else:
-            med_result = Translation(
-                x=int(nonzero_field[0].median()), y=int(nonzero_field[1].median())
-            )
-
             low_l = percentile(nonzero_field, l)
             high_l = percentile(nonzero_field, h)
             mid = 0.5 * (low_l + high_l)

--- a/corgie/stack.py
+++ b/corgie/stack.py
@@ -230,6 +230,7 @@ class FieldSet:
 
         for z, layer in zip(z_list[1:], self.layers[1:]):
             trans = helpers.percentile_trans_adjuster(agg_field)
+            trans = (trans // 2**(layer.data_mip - mip)) * 2**(layer.data_mip - mip)
             corgie_logger.debug(f"{trans}")
             abcube = abcube.reset_coords(zs=z, ze=z + 1, in_place=True)
             abcube = abcube.translate(x_offset=trans.y, y_offset=trans.x, mip=mip)

--- a/corgie/stack.py
+++ b/corgie/stack.py
@@ -230,7 +230,7 @@ class FieldSet:
 
         for z, layer in zip(z_list[1:], self.layers[1:]):
             trans = helpers.percentile_trans_adjuster(agg_field)
-            trans = (trans // 2**(layer.data_mip - mip)) * 2**(layer.data_mip - mip)
+            trans = trans.round_to_mip(mip, layer.data_mip)
             corgie_logger.debug(f"{trans}")
             abcube = abcube.reset_coords(zs=z, ze=z + 1, in_place=True)
             abcube = abcube.translate(x_offset=trans.y, y_offset=trans.x, mip=mip)


### PR DESCRIPTION
This PR ensures bounding box adjustments during translation shifts are happening only in full voxel size increments, rather than assuming MIP0 voxel size.

It seems to work for the particular case we discussed - not sure if there are other places that require this or similar changes.