### PR TITLE
Pass command name into scheduler

### DIFF
--- a/corgie/main.py
+++ b/corgie/main.py
@@ -67,7 +67,8 @@ def cli(ctx, device, verbose, **kwargs):
         configure_logger(verbose)
         ctx.obj = {}
         DataBackendBase.default_device = device
-        corgie_logger.debug("Creting scheduler...")
+        corgie_logger.debug("Creating scheduler...")
+        kwargs['command_name'] = ctx.command.name
         ctx.obj['scheduler'] = scheduling.parse_scheduler_from_kwargs(
                 kwargs)
 


### PR DESCRIPTION
This is useful so the checkpoint file can be associated with the corgie command -- e.g. stored as `~/.mazepa/job_checkpoints/align/job_checkpoint_2021_04_19T16_22_57.json` or `~/.mazepa/job_checkpoints/render/job_checkpoint_2021_04_19T16_22_57.json` as opposed to `~/.mazepa/job_checkpoints/job_checkpoint_2021_04_19T16_22_57.json`