### PR TITLE
(feat) Add fill-nearest & seethrough-block methods

### DIFF
--- a/corgie/cli/__init__.py
+++ b/corgie/cli/__init__.py
@@ -22,6 +22,7 @@ from corgie.cli.normalize_by_spec import normalize_by_spec
 from corgie.cli.downsample_by_spec import downsample_by_spec
 from corgie.cli.compare_sections import compare_sections
 from corgie.cli.seethrough_block import seethrough_block
+from corgie.cli.fill_nearest import fill_nearest
 
 COMMAND_LIST = []
 COMMAND_LIST.append(downsample)
@@ -45,6 +46,7 @@ COMMAND_LIST.append(apply_processor_by_spec)
 COMMAND_LIST.append(normalize_by_spec)
 COMMAND_LIST.append(downsample_by_spec)
 COMMAND_LIST.append(seethrough_block)
+COMMAND_LIST.append(fill_nearest)
 
 
 def get_command_list():

--- a/corgie/cli/__init__.py
+++ b/corgie/cli/__init__.py
@@ -1,73 +1,50 @@
-from copy import deepcopy
-
-COMMAND_LIST = []
-
-from corgie.cli.downsample import downsample
-
-COMMAND_LIST.append(downsample)
-from corgie.cli.upsample import upsample
-
-COMMAND_LIST.append(upsample)
-from corgie.cli.compute_field import compute_field
-
-COMMAND_LIST.append(compute_field)
-from corgie.cli.compute_stats import compute_stats
-
-COMMAND_LIST.append(compute_stats)
-from corgie.cli.normalize import normalize
-
-COMMAND_LIST.append(normalize)
-from corgie.cli.align_block import align_block
-
-COMMAND_LIST.append(align_block)
-from corgie.cli.align import align
-
-COMMAND_LIST.append(align)
-from corgie.cli.render import render
-
-COMMAND_LIST.append(render)
-from corgie.cli.copy import copy
-
-COMMAND_LIST.append(copy)
-from corgie.cli.apply_processor import apply_processor
-
-COMMAND_LIST.append(apply_processor)
-from corgie.cli.invert_field import invert_field
-
-COMMAND_LIST.append(invert_field)
-from corgie.cli.create_skeletons import create_skeletons
-
-COMMAND_LIST.append(create_skeletons)
-from corgie.cli.transform_skeletons import transform_skeletons
-
-COMMAND_LIST.append(transform_skeletons)
-from corgie.cli.filter_skeletons import filter_skeletons
-
-COMMAND_LIST.append(filter_skeletons)
-from corgie.cli.merge_copy import merge_copy
-
-COMMAND_LIST.append(merge_copy)
-from corgie.cli.compute_field_by_spec import compute_field_by_spec
-
-COMMAND_LIST.append(compute_field_by_spec)
-from corgie.cli.merge_render import merge_render
-
-COMMAND_LIST.append(merge_render)
-from corgie.cli.apply_processor_by_spec import apply_processor_by_spec
-
-COMMAND_LIST.append(apply_processor_by_spec)
-from corgie.cli.normalize_by_spec import normalize_by_spec
-
-COMMAND_LIST.append(normalize_by_spec)
-from corgie.cli.downsample_by_spec import downsample_by_spec
-
-COMMAND_LIST.append(downsample_by_spec)
-from corgie.cli.compare_sections import compare_sections
-
-COMMAND_LIST.append(compare_sections)
-
 # To add new commands, create a file in this folder implementing a command,
 # import the command here and add it to the list:
+from corgie.cli.downsample import downsample
+from corgie.cli.upsample import upsample
+from corgie.cli.compute_field import compute_field
+from corgie.cli.compute_stats import compute_stats
+from corgie.cli.normalize import normalize
+from corgie.cli.align_block import align_block
+from corgie.cli.align import align
+from corgie.cli.render import render
+from corgie.cli.copy import copy
+from corgie.cli.apply_processor import apply_processor
+from corgie.cli.invert_field import invert_field
+from corgie.cli.create_skeletons import create_skeletons
+from corgie.cli.transform_skeletons import transform_skeletons
+from corgie.cli.filter_skeletons import filter_skeletons
+from corgie.cli.merge_copy import merge_copy
+from corgie.cli.compute_field_by_spec import compute_field_by_spec
+from corgie.cli.merge_render import merge_render
+from corgie.cli.apply_processor_by_spec import apply_processor_by_spec
+from corgie.cli.normalize_by_spec import normalize_by_spec
+from corgie.cli.downsample_by_spec import downsample_by_spec
+from corgie.cli.compare_sections import compare_sections
+from corgie.cli.seethrough_block import seethrough_block
+
+COMMAND_LIST = []
+COMMAND_LIST.append(downsample)
+COMMAND_LIST.append(upsample)
+COMMAND_LIST.append(compute_field)
+COMMAND_LIST.append(compute_stats)
+COMMAND_LIST.append(normalize)
+COMMAND_LIST.append(align_block)
+COMMAND_LIST.append(align)
+COMMAND_LIST.append(render)
+COMMAND_LIST.append(copy)
+COMMAND_LIST.append(apply_processor)
+COMMAND_LIST.append(invert_field)
+COMMAND_LIST.append(create_skeletons)
+COMMAND_LIST.append(transform_skeletons)
+COMMAND_LIST.append(filter_skeletons)
+COMMAND_LIST.append(merge_copy)
+COMMAND_LIST.append(compute_field_by_spec)
+COMMAND_LIST.append(merge_render)
+COMMAND_LIST.append(apply_processor_by_spec)
+COMMAND_LIST.append(normalize_by_spec)
+COMMAND_LIST.append(downsample_by_spec)
+COMMAND_LIST.append(seethrough_block)
 
 
 def get_command_list():

--- a/corgie/cli/fill_nearest.py
+++ b/corgie/cli/fill_nearest.py
@@ -1,0 +1,202 @@
+import click
+import six
+from copy import deepcopy
+
+from corgie import scheduling, argparsers, helpers, stack
+
+from corgie.log import logger as corgie_logger
+from corgie.layers import get_layer_types, DEFAULT_LAYER_TYPE, str_to_layer_type
+from corgie.boundingcube import get_bcube_from_coords
+
+from corgie.argparsers import (
+    LAYER_HELP_STR,
+    create_layer_from_spec,
+    corgie_optgroup,
+    corgie_option,
+    create_stack_from_spec,
+)
+
+
+class FillNearestJob(scheduling.Job):
+    def __init__(
+        self, src_stack, dst_stack, bcube, mip, radius, chunk_xy,
+    ):
+        """Write image, filling in masked regions with nearest non-masked image
+
+        This is useful when a model requires a filled in image.
+        """
+        self.src_stack = src_stack
+        self.dst_stack = dst_stack
+        self.bcube = bcube
+        self.mip = mip
+        self.radius = radius
+        self.chunk_xy = chunk_xy
+        super().__init__()
+
+    def task_generator(self):
+        chunks = self.dst_stack.get_layers()[0].break_bcube_into_chunks(
+            bcube=self.bcube,
+            chunk_xy=self.chunk_xy,
+            chunk_z=1,
+            mip=self.mip,
+            return_generator=True,
+        )
+
+        tasks = (
+            FillNearestTask(
+                self.src_stack,
+                self.dst_stack,
+                mip=self.mip,
+                bcube=chunk,
+                radius=self.radius,
+            )
+            for chunk in chunks
+        )
+        corgie_logger.info(
+            f"Yielding fill nearest tasks for bcube: {self.bcube}, MIP: {self.mip}"
+        )
+
+        yield tasks
+
+
+class FillNearestTask(scheduling.Task):
+    def __init__(
+        self, src_stack, dst_stack, mip, bcube, radius=2,
+    ):
+        super().__init__(self)
+        self.src_stack = src_stack
+        self.dst_stack = dst_stack
+        self.mip = mip
+        self.bcube = bcube
+        self.radius = radius
+        self.count_threshold = 10
+
+    def get_masks(self, data_dict, bcube):
+        agg_mask = helpers.zeros(
+            (bcube.x_size(self.mip), bcube.y_size(self.mip)), dtype=bool
+        )
+        mask_layers = self.dst_stack.get_layers_of_type(["mask"])
+        mask_layer_names = [l.name for l in mask_layers]
+        for n, d in six.iteritems(data_dict):
+            if n in mask_layer_names:
+                if agg_mask is None:
+                    agg_mask = d
+                else:
+                    agg_mask = (agg_mask + d) > 0
+        return agg_mask
+
+    def execute(self):
+        radii = [i for r in range(1, self.radius + 1) for i in [r, -r]]
+        z = self.bcube.z_range()[0]
+        _, src_data_dict = self.src_stack.read_data_dict(
+            bcube=self.bcube, mip=self.mip, add_prefix=False, translation_adjuster=None,
+        )
+        layer = self.dst_stack.get_layers_of_type("img")[0]
+        agg_img = src_data_dict[f"{layer.name}"]
+        agg_mask = self.get_masks(data_dict=src_data_dict, bcube=self.bcube)
+        mask_count = agg_mask.sum()
+        k = 0
+        while (mask_count > self.count_threshold) and (k < len(radii)):
+            corgie_logger.debug(f"mask_count={mask_count}")
+            corgie_logger.debug(f"radius={radii[k]}")
+            bcube = self.bcube.reset_coords(
+                zs=z + radii[k], ze=z + radii[k] + 1, in_place=False
+            )
+            _, src_data_dict = self.src_stack.read_data_dict(
+                bcube=bcube, mip=self.mip, add_prefix=False, translation_adjuster=None,
+            )
+            img = src_data_dict[f"{layer.name}"]
+            agg_img[agg_mask] = img[agg_mask]
+            mask = self.get_masks(data_dict=src_data_dict, bcube=bcube)
+            agg_mask = (agg_mask == 1) * (mask == 1)
+            mask_count = agg_mask.sum()
+            k += 1
+        layer.write(agg_img, bcube=self.bcube, mip=self.mip)
+
+
+@click.command()
+# Layers
+@corgie_optgroup("Layer Parameters")
+@corgie_option(
+    "--src_layer_spec",
+    "-s",
+    nargs=1,
+    type=str,
+    required=True,
+    multiple=True,
+    help="Source layer spec. Use multiple times to include all masks, fields, images. "
+    + LAYER_HELP_STR,
+)
+@corgie_option(
+    "--dst_folder",
+    nargs=1,
+    type=str,
+    required=True,
+    help="Folder where aligned stack will go",
+)
+@corgie_option("--suffix", nargs=1, type=str, default=None)
+@corgie_optgroup("Fill Nearest Method Specification")
+@corgie_option("--mip", nargs=1, type=int, required=True)
+@corgie_option("--radius", nargs=1, type=int, default=2)
+@corgie_option("--chunk_xy", nargs=1, type=int, default=1024)
+@corgie_optgroup("Data Region Specification")
+@corgie_option("--start_coord", nargs=1, type=str, required=True)
+@corgie_option("--end_coord", nargs=1, type=str, required=True)
+@corgie_option("--coord_mip", nargs=1, type=int, default=0)
+@click.pass_context
+def fill_nearest(
+    ctx,
+    src_layer_spec,
+    dst_folder,
+    chunk_xy,
+    start_coord,
+    end_coord,
+    coord_mip,
+    suffix,
+    mip,
+    radius,
+    force_chunk_z=1,
+):
+    scheduler = ctx.obj["scheduler"]
+
+    if suffix is None:
+        suffix = "_seethrough"
+    else:
+        suffix = f"_{suffix}"
+
+    crop, pad = 0, 0
+    corgie_logger.debug("Setting up layers...")
+    src_stack = create_stack_from_spec(src_layer_spec, name="src", readonly=True)
+    src_stack.folder = dst_folder
+    dst_stack = stack.create_stack_from_reference(
+        reference_stack=src_stack,
+        folder=dst_folder,
+        name="dst",
+        types=["img", "mask"],
+        readonly=False,
+        suffix=suffix,
+        overwrite=True,
+        force_chunk_z=force_chunk_z,
+    )
+    bcube = get_bcube_from_coords(start_coord, end_coord, coord_mip)
+
+    fill_nearest_job = FillNearestJob(
+        src_stack=src_stack,
+        dst_stack=dst_stack,
+        bcube=bcube,
+        radius=radius,
+        mip=mip,
+        chunk_xy=chunk_xy,
+    )
+    # create scheduler and execute the job
+    scheduler.register_job(
+        fill_nearest_job, job_name="Fill Nearest Block {}".format(bcube)
+    )
+
+    scheduler.execute_until_completion()
+    result_report = (
+        f"Rendered layers {[str(l) for l in src_stack.get_layers_of_type('img')]}. "
+        f"Results in {[str(l) for l in dst_stack.get_layers_of_type('img')]}"
+    )
+    corgie_logger.info(result_report)
+

--- a/corgie/cli/seethrough_block.py
+++ b/corgie/cli/seethrough_block.py
@@ -1,0 +1,197 @@
+import click
+from copy import deepcopy
+
+from corgie import scheduling, argparsers, helpers, stack
+
+from corgie.log import logger as corgie_logger
+from corgie.layers import get_layer_types, DEFAULT_LAYER_TYPE, str_to_layer_type
+from corgie.boundingcube import get_bcube_from_coords
+
+from corgie.argparsers import (
+    LAYER_HELP_STR,
+    create_layer_from_spec,
+    corgie_optgroup,
+    corgie_option,
+    create_stack_from_spec,
+)
+
+from corgie.cli.render import RenderJob
+from corgie.cli.copy import CopyJob
+from corgie.cli.vote import VoteJob
+from corgie.cli.compute_field import ComputeFieldJob
+from corgie.cli.compare_sections import CompareSectionsJob
+
+from corgie.cli.downsample import DownsampleJob
+from corgie.cli.upsample import UpsampleJob
+
+
+class SeethroughBlockJob(scheduling.Job):
+    def __init__(
+        self,
+        src_stack,
+        dst_stack,
+        render_method,
+        bcube,
+        seethrough_method=None,
+        suffix=None,
+    ):
+        """Write out a block sequentially using seethrough method
+
+        This is useful when a model requires a filled in image.
+        """
+        self.src_stack = src_stack
+        self.dst_stack = dst_stack
+        self.bcube = bcube
+        self.seethrough_method = seethrough_method
+        self.render_method = render_method
+        self.suffix = suffix
+        super().__init__()
+
+    def task_generator(self):
+        seethrough_offset = -1
+        seethrough_mask_layer = self.dst_stack.create_sublayer(
+            f"seethrough_mask{self.suffix}",
+            layer_type="mask",
+            overwrite=True,
+            force_chunk_z=1,
+        )
+        z_start, z_stop = self.bcube.z_range()
+        for z in range(z_start, z_stop):
+            bcube = self.bcube.reset_coords(zs=z, ze=z + 1, in_place=False)
+            if z == z_start:
+                corgie_logger.debug(f"Copy section {z}")
+                render_job = self.render_method(
+                    src_stack=self.src_stack,
+                    dst_stack=self.dst_stack,
+                    bcube=bcube,
+                    mips=self.seethrough_method.mip,
+                    blackout_masks=True,
+                )
+
+                yield from render_job.task_generator
+                yield scheduling.wait_until_done
+            else:
+                # Now, we'll apply misalignment detection to produce a mask
+                # this mask will be used in the final render step
+                seethrough_mask_job = self.seethrough_method(
+                    src_stack=self.src_stack,
+                    tgt_stack=self.dst_stack,
+                    bcube=bcube,
+                    tgt_z_offset=seethrough_offset,
+                    suffix=self.suffix,
+                    dst_layer=seethrough_mask_layer,
+                )
+
+                yield from seethrough_mask_job.task_generator
+                yield scheduling.wait_until_done
+                corgie_logger.debug(f"Render {z}")
+                render_job = self.render_method(
+                    src_stack=self.src_stack,
+                    dst_stack=self.dst_stack,
+                    bcube=bcube,
+                    blackout_masks=False,
+                    seethrough_mask_layer=seethrough_mask_layer,
+                    seethrough_offset=seethrough_offset,
+                    mips=self.seethrough_method.mip,
+                )
+                yield from render_job.task_generator
+                yield scheduling.wait_until_done
+
+
+@click.command()
+# Layers
+@corgie_optgroup("Layer Parameters")
+@corgie_option(
+    "--src_layer_spec",
+    "-s",
+    nargs=1,
+    type=str,
+    required=True,
+    multiple=True,
+    help="Source layer spec. Use multiple times to include all masks, fields, images. "
+    + LAYER_HELP_STR,
+)
+@corgie_option(
+    "--dst_folder",
+    nargs=1,
+    type=str,
+    required=True,
+    help="Folder where aligned stack will go",
+)
+@corgie_option("--suffix", nargs=1, type=str, default=None)
+@corgie_optgroup("Render Method Specification")
+@corgie_option("--seethrough_spec", nargs=1, type=str, default=None)
+@corgie_option("--seethrough_spec_mip", nargs=1, type=int, default=None)
+@corgie_option("--chunk_xy", nargs=1, type=int, default=1024)
+@corgie_optgroup("Data Region Specification")
+@corgie_option("--start_coord", nargs=1, type=str, required=True)
+@corgie_option("--end_coord", nargs=1, type=str, required=True)
+@corgie_option("--coord_mip", nargs=1, type=int, default=0)
+@click.pass_context
+def seethrough_block(
+    ctx,
+    src_layer_spec,
+    dst_folder,
+    chunk_xy,
+    start_coord,
+    end_coord,
+    coord_mip,
+    suffix,
+    seethrough_spec,
+    seethrough_spec_mip,
+    force_chunk_z=1,
+):
+    scheduler = ctx.obj["scheduler"]
+
+    if suffix is None:
+        suffix = "_seethrough"
+    else:
+        suffix = f"_{suffix}"
+
+    crop, pad = 0, 0
+    corgie_logger.debug("Setting up layers...")
+    src_stack = create_stack_from_spec(src_layer_spec, name="src", readonly=True)
+    src_stack.folder = dst_folder
+    dst_stack = stack.create_stack_from_reference(
+        reference_stack=src_stack,
+        folder=dst_folder,
+        name="dst",
+        types=["img", "mask"],
+        readonly=False,
+        suffix=suffix,
+        overwrite=True,
+        force_chunk_z=force_chunk_z,
+    )
+    render_method = helpers.PartialSpecification(
+        f=RenderJob, pad=pad, chunk_xy=chunk_xy, chunk_z=1, render_masks=False,
+    )
+    seethrough_method = helpers.PartialSpecification(
+        f=CompareSectionsJob,
+        mip=seethrough_spec_mip,
+        processor_spec=seethrough_spec,
+        chunk_xy=chunk_xy,
+        pad=pad,
+        crop=pad,
+    )
+    bcube = get_bcube_from_coords(start_coord, end_coord, coord_mip)
+
+    seethrough_block_job = SeethroughBlockJob(
+        src_stack=src_stack,
+        dst_stack=dst_stack,
+        bcube=bcube,
+        render_method=render_method,
+        seethrough_method=seethrough_method,
+        suffix=suffix,
+    )
+    # create scheduler and execute the job
+    scheduler.register_job(
+        seethrough_block_job, job_name="Seethrough Block {}".format(bcube)
+    )
+
+    scheduler.execute_until_completion()
+    result_report = (
+        f"Rendered layers {[str(l) for l in src_stack.get_layers_of_type('img')]}. "
+        f"Results in {[str(l) for l in dst_stack.get_layers_of_type('img')]}"
+    )
+    corgie_logger.info(result_report)
+


### PR DESCRIPTION
Use fill-nearest to fill mask with nearest pixels in z that are not masked, up to a given radius. Use seethrough-block to fill mask with previous pixels in z that are not masked, up to the beginning of the block.