### PR TITLE
Add basic block-stitching

### DIFF
--- a/corgie/block.py
+++ b/corgie/block.py
@@ -10,7 +10,7 @@ class Block:
         self.previous = previous
 
     def __str__(self):
-        return f"Block {self.start}->{self.stop}\nsrc_stack={self.src_stack.name}\ndst_stack={self.dst_stack.name}"
+        return f"Block {self.start}->{self.stop}, src_stack={self.src_stack.name}, dst_stack={self.dst_stack.name}"
 
     def __repr__(self):
         return self.__str__()
@@ -26,17 +26,11 @@ class Block:
         """
         if self.previous is None:
             return None
-        src_stack = deepcopy(self.dst_stack)
-        dst_stack = deepcopy(self.previous.dst_stack)
-        for stack in [src_stack, dst_stack]:
-            layers = stack.get_layers_of_type("field")
-            for l in layers:
-                stack.remove_layer(l.name)
         return Block(
             start=self.previous.stop,
             stop=self.previous.stop + stitch_size,
-            src_stack=src_stack,
-            dst_stack=dst_stack,
+            src_stack=self.dst_stack,
+            dst_stack=self.previous.dst_stack,
         )
 
     def get_neighbors(self, dist):

--- a/corgie/block.py
+++ b/corgie/block.py
@@ -26,11 +26,17 @@ class Block:
         """
         if self.previous is None:
             return None
+        src_stack = deepcopy(self.dst_stack)
+        dst_stack = deepcopy(self.previous.dst_stack)
+        for stack in [src_stack, dst_stack]:
+            layers = stack.get_layers_of_type("field")
+            for l in layers:
+                stack.remove_layer(l.name)
         return Block(
             start=self.previous.stop,
             stop=self.previous.stop + stitch_size,
-            src_stack=self.dst_stack,
-            dst_stack=self.previous.dst_stack,
+            src_stack=src_stack,
+            dst_stack=dst_stack,
         )
 
     def get_neighbors(self, dist):

--- a/corgie/block.py
+++ b/corgie/block.py
@@ -1,11 +1,119 @@
+from copy import deepcopy
+
+
 class Block:
-    def __init__(self, z_start, z_end, special_args={}):
-        self.z_start = z_start
-        self.z_end = z_end
-        self.special_args = special_args
+    def __init__(self, start, stop, src_stack, dst_stack, previous=None):
+        self.start = start
+        self.stop = stop
+        self.src_stack = src_stack
+        self.dst_stack = dst_stack
+        self.previous = previous
 
     def __str__(self):
-        return f"Block {self.z_start}->{self.z_end}"
+        return f"Block {self.start}->{self.stop}\nsrc_stack={self.src_stack.name}\ndst_stack={self.dst_stack.name}"
 
     def __repr__(self):
         return self.__str__()
+
+    def overlap(self, stitch_size, field_name):
+        """Get block representing overlap between current and previous block
+
+        Modify src_stack so that its conditioned with dst_stack's field
+
+        Args:
+            stitch_size (int): number of sections to use in stitching
+            field_name (str)
+
+        Returns:
+            new Block
+        """
+        if self.previous is None:
+            return None
+        src_stack = deepcopy(self.src_stack)
+        if field_name in self.dst_stack:
+            src_stack.add_layer(self.dst_stack[field_name])
+        return Block(
+            start=self.previous.stop,
+            stop=self.previous.stop + stitch_size,
+            src_stack=src_stack,
+            dst_stack=self.previous.dst_stack,
+        )
+
+    def get_neighbors(self, dist):
+        """Get list of previous blocks where stop is within dist of current block's start.
+        Order from furthest to nearest block (convention of FieldSet).
+
+        Args:
+            dist (int)
+
+        Returns:
+            list of blocks
+        """
+        neighbors = []
+        prev = self.previous
+        if prev is None:
+            return neighbors
+        while self.start - prev.stop < dist:
+            neighbors.insert(0, prev)
+            prev = prev.previous
+            if prev is None:
+                break
+        return neighbors
+
+    def get_bcube(self, bcube):
+        return bcube.reset_coords(zs=self.start, ze=self.stop, in_place=False)
+
+
+def get_blocks(
+    start,
+    stop,
+    block_size,
+    block_overlap,
+    skip_list,
+    src_stack,
+    even_stack,
+    odd_stack,
+):
+    partitions = partition(
+        range(start, stop), sz=block_size, overlap=block_overlap, skip=skip_list
+    )
+    blocks = []
+    previous = None
+    for k, p in enumerate(partitions):
+        dst_stack = even_stack if k % 2 == 0 else odd_stack
+        block = Block(
+            start=p.start,
+            stop=p.stop,
+            src_stack=src_stack,
+            dst_stack=dst_stack,
+            previous=previous,
+        )
+        blocks.append(block)
+        previous = block
+    return blocks
+
+
+def partition(xrange, sz, overlap=0, skip=[]):
+    """Divide range into subsets specified by size, overlap, and indices to skip.
+
+    Args:
+        xrange (range)
+        sz (int): minimum size of subset
+        overlap (int): amount of overlap between subsets
+        skip ([int]): indices to skip in start/end of subset (unless start/end of xrange)
+
+    Returns:
+        list of subset ranges
+    """
+    subsets = []
+    x = xrange.start
+    while x < xrange.stop:
+        xs_start = x
+        xs_stop = x + sz
+        while xs_stop + overlap in skip and xs_stop + overlap < xrange.stop:
+            xs_stop += 1
+        x = xs_stop
+        xs_stop += overlap
+        xs_stop = min(xs_stop, xrange.stop)
+        subsets.append(range(xs_start, xs_stop))
+    return subsets

--- a/corgie/block.py
+++ b/corgie/block.py
@@ -15,27 +15,21 @@ class Block:
     def __repr__(self):
         return self.__str__()
 
-    def overlap(self, stitch_size, field_name):
+    def overlap(self, stitch_size):
         """Get block representing overlap between current and previous block
-
-        Modify src_stack so that its conditioned with dst_stack's field
 
         Args:
             stitch_size (int): number of sections to use in stitching
-            field_name (str)
 
         Returns:
             new Block
         """
         if self.previous is None:
             return None
-        src_stack = deepcopy(self.src_stack)
-        if field_name in self.dst_stack:
-            src_stack.add_layer(self.dst_stack[field_name])
         return Block(
             start=self.previous.stop,
             stop=self.previous.stop + stitch_size,
-            src_stack=src_stack,
+            src_stack=self.dst_stack,
             dst_stack=self.previous.dst_stack,
         )
 

--- a/corgie/boundingcube.py
+++ b/corgie/boundingcube.py
@@ -5,31 +5,37 @@ import numpy as np
 
 from corgie.helpers import crop
 
-def get_bcube_from_coords(start_coord, end_coord, coord_mip,
-        cant_be_empty=True):
-    xs, ys, zs = [int(i) for i in start_coord.split(',')]
-    xe, ye, ze = [int(i) for i in end_coord.split(',')]
+
+def get_bcube_from_coords(start_coord, end_coord, coord_mip, cant_be_empty=True):
+    xs, ys, zs = [int(i) for i in start_coord.split(",")]
+    xe, ye, ze = [int(i) for i in end_coord.split(",")]
     bcube = BoundingCube(xs, xe, ys, ye, zs, ze, coord_mip)
 
     if cant_be_empty and bcube.area() * bcube.z_size() == 0:
-        raise Exception("Attempted creation of an empty bounding "
-                "when 'cant_be_empty' flag is set to True")
+        raise Exception(
+            "Attempted creation of an empty bounding "
+            "when 'cant_be_empty' flag is set to True"
+        )
 
     return bcube
+
 
 def get_bcube_from_vertices(vertices, resolution, mip, cant_be_empty=True):
     bcube_args = []
     for dim in range(3):
-        dim_min = min(vertices[:,dim]) / resolution[dim]
-        dim_max = max(vertices[:,dim]) / resolution[dim] + 1
+        dim_min = min(vertices[:, dim]) / resolution[dim]
+        dim_max = max(vertices[:, dim]) / resolution[dim] + 1
         bcube_args.append(dim_min)
         bcube_args.append(dim_max)
     bcube = BoundingCube(*bcube_args, mip)
     if cant_be_empty and bcube.area() * bcube.z_size() == 0:
-        raise Exception("Attempted creation of an empty bounding "
-                "when 'cant_be_empty' flag is set to True")
+        raise Exception(
+            "Attempted creation of an empty bounding "
+            "when 'cant_be_empty' flag is set to True"
+        )
 
     return bcube
+
 
 class BoundingCube:
     def __init__(self, xs, xe, ys, ye, zs, ze, mip):
@@ -43,8 +49,11 @@ class BoundingCube:
     # def insets(self, other, mip):
 
     def get_bounding_pts(self):
-        return (self.m0_x[0], self.m0_y[0], self.z[0]), \
-               (self.m0_x[1], self.m0_y[1], self.z[1])
+        return (self.m0_x[0], self.m0_y[0], self.z[0]), (
+            self.m0_x[1],
+            self.m0_y[1],
+            self.z[1],
+        )
 
     def contains(self, other):
         if self.m0_y[1] < other.m0_y[1]:
@@ -63,7 +72,6 @@ class BoundingCube:
 
         return True
 
-
     # TODO: delete?
     def intersects(self, other):
         assert type(other) == type(self)
@@ -81,47 +89,50 @@ class BoundingCube:
             return False
         return True
 
-    def reset_coords(self, xs=None, xe=None,
-            ys=None, ye=None, zs=None, ze=None, mip=0, in_place=True):
+    def reset_coords(
+        self, xs=None, xe=None, ys=None, ye=None, zs=None, ze=None, mip=0, in_place=True
+    ):
 
         if in_place:
             target_cube = self
         else:
             target_cube = copy.deepcopy(self)
-        scale_factor = 2**mip
+        scale_factor = 2 ** mip
         if xs is not None:
-            target_cube.m0_x =  (int(xs * scale_factor), target_cube.m0_x[1])
+            target_cube.m0_x = (int(xs * scale_factor), target_cube.m0_x[1])
         if xe is not None:
             target_cube.m0_x = (target_cube.m0_x[0], int(xe * scale_factor))
 
         if ys is not None:
-            target_cube.m0_y =  (int(ys * scale_factor), target_cube.m0_y[1])
+            target_cube.m0_y = (int(ys * scale_factor), target_cube.m0_y[1])
         if ye is not None:
             target_cube.m0_y = (target_cube.m0_y[0], int(ye * scale_factor))
 
         if zs is not None:
-            target_cube.z =  (int(zs), target_cube.z[1])
+            target_cube.z = (int(zs), target_cube.z[1])
         if ze is not None:
             target_cube.z = (target_cube.z[0], int(ze))
 
         return target_cube
 
     def get_offset(self, mip=0):
-        scale_factor = 2**mip
-        return (self.m0_x[0] / scale_factor + self.x_size(mip=0) / 2 / scale_factor,
-                self.m0_y[0] / scale_factor + self.y_size(mip=0) / 2 / scale_factor)
+        scale_factor = 2 ** mip
+        return (
+            self.m0_x[0] / scale_factor + self.x_size(mip=0) / 2 / scale_factor,
+            self.m0_y[0] / scale_factor + self.y_size(mip=0) / 2 / scale_factor,
+        )
 
     def x_range(self, mip):
-        scale_factor = 2**mip
+        scale_factor = 2 ** mip
         xl = int(round((self.m0_x[1] - self.m0_x[0]) / scale_factor))
         xs = floor(self.m0_x[0] / scale_factor)
-        return [xs, xs+xl]
+        return [xs, xs + xl]
 
     def y_range(self, mip):
-        scale_factor = 2**mip
+        scale_factor = 2 ** mip
         yl = int(round((self.m0_y[1] - self.m0_y[0]) / scale_factor))
         ys = floor(self.m0_y[0] / scale_factor)
-        return [ys, ys+yl]
+        return [ys, ys + yl]
 
     def z_range(self):
         return list(copy.deepcopy(self.z))
@@ -151,45 +162,53 @@ class BoundingCube:
     def to_filename(self, mip=0):
         minpt = self.minpt(mip)
         maxpt = self.maxpt(mip)
-        return '_'.join((str(minpt[i]) + '-' + str(maxpt[i]) for i in range(3)))
+        return "_".join((str(minpt[i]) + "-" + str(maxpt[i]) for i in range(3)))
 
     @property
     def size(self, mip=0):
         return self.x_size(mip=mip), self.y_size(mip=mip), self.z_size()
 
     def crop(self, crop_xy, mip):
-        scale_factor = 2**mip
+        scale_factor = 2 ** mip
         m0_crop_xy = crop_xy * scale_factor
-        self.set_m0(self.m0_x[0] + m0_crop_xy,
-                    self.m0_x[1] - m0_crop_xy,
-                    self.m0_y[0] + m0_crop_xy,
-                    self.m0_y[1] - m0_crop_xy)
+        self.set_m0(
+            self.m0_x[0] + m0_crop_xy,
+            self.m0_x[1] - m0_crop_xy,
+            self.m0_y[0] + m0_crop_xy,
+            self.m0_y[1] - m0_crop_xy,
+        )
 
     def uncrop(self, crop_xy, mip):
-        """Uncrop the bounding box by crop_xy at given MIP level
-        """
-        scale_factor = 2**mip
+        """Uncrop the bounding box by crop_xy at given MIP level"""
+        scale_factor = 2 ** mip
         m0_crop_xy = crop_xy * scale_factor
         result = self.clone()
-        result.reset_coords(xs=self.m0_x[0] - m0_crop_xy,
-                        xe=self.m0_x[1] + m0_crop_xy,
-                        ys=self.m0_y[0] - m0_crop_xy,
-                        ye=self.m0_y[1] + m0_crop_xy,
-                        mip=0)
+        result.reset_coords(
+            xs=self.m0_x[0] - m0_crop_xy,
+            xe=self.m0_x[1] + m0_crop_xy,
+            ys=self.m0_y[0] - m0_crop_xy,
+            ye=self.m0_y[1] + m0_crop_xy,
+            mip=0,
+        )
         return result
 
     def zeros(self, mip):
-        return np.zeros((self.x_size(mip), self.y_size(mip), self.z_size()),
-                dtype=np.float32)
+        return np.zeros(
+            (self.x_size(mip), self.y_size(mip), self.z_size()), dtype=np.float32
+        )
 
     def x_res_displacement(self, d_pixels, mip):
         disp_prop = d_pixels / self.x_size(mip=0)
-        result = np.full((self.x_size(mip), self.y_size(mip)), disp_prop, dtype=np.float32)
+        result = np.full(
+            (self.x_size(mip), self.y_size(mip)), disp_prop, dtype=np.float32
+        )
         return result
 
     def y_res_displacement(self, d_pixels, mip):
         disp_prop = d_pixels / self.y_size(mip=0)
-        result = np.full((self.x_size(mip), self.y_size(mip)), disp_prop, dtype=np.float32)
+        result = np.full(
+            (self.x_size(mip), self.y_size(mip)), disp_prop, dtype=np.float32
+        )
         return result
 
     def spoof_x_y_residual(self, x_d, y_d, mip, crop_amount=0):
@@ -200,15 +219,14 @@ class BoundingCube:
         return result
 
     def __eq__(self, x):
-        if isinstance(x, BoundingBox):
-            return (self.m0_x == x.m0_x) and (self.m0_y == x.m0_y) and \
-                    (self.z == x.z)
+        if isinstance(x, BoundingCube):
+            return (self.m0_x == x.m0_x) and (self.m0_y == x.m0_y) and (self.z == x.z)
         return False
 
     def __str__(self, mip=0):
         return "[MIP {}] {}, {}, {}".format(
-                mip, self.x_range(mip), self.y_range(mip),
-                self.z_range())
+            mip, self.x_range(mip), self.y_range(mip), self.z_range()
+        )
 
     def __repr__(self):
         return self.__str__(mip=0)
@@ -218,15 +236,17 @@ class BoundingCube:
         assert isinstance(y, int)
         assert isinstance(z, int)
 
-        scale_factor = 2**mip
+        scale_factor = 2 ** mip
 
-        return BoundingCube(xs=self.m0_x[0] + x,
-                           xe=self.m0_x[1] + x,
-                           ys=self.m0_y[0] + y,
-                           ye=self.m0_y[1] + y,
-                           zs=self.z[0] + z,
-                           ze=self.z[1] + z,
-                           mip=mip)
+        return BoundingCube(
+            xs=self.m0_x[0] + x,
+            xe=self.m0_x[1] + x,
+            ys=self.m0_y[0] + y,
+            ye=self.m0_y[1] + y,
+            zs=self.z[0] + z,
+            ze=self.z[1] + z,
+            mip=mip,
+        )
 
     def clone(self):
         return copy.deepcopy(self)
@@ -239,19 +259,16 @@ class BoundingCube:
         y_range = self.y_range(mip=mip)
         z_range = self.z_range()
         return BoundingCube(
-                xs=x_range[0] + x_offset,
-                xe=x_range[1] + x_offset,
-                ys=y_range[0] + y_offset,
-                ye=y_range[1] + y_offset,
-                zs=z_range[0] + z_offset,
-                ze=z_range[1] + z_offset,
-                mip=mip
-            )
-
+            xs=x_range[0] + x_offset,
+            xe=x_range[1] + x_offset,
+            ys=y_range[0] + y_offset,
+            ye=y_range[1] + y_offset,
+            zs=z_range[0] + z_offset,
+            ze=z_range[1] + z_offset,
+            mip=mip,
+        )
 
     def to_slices(self, zs, ze=None, mip=0):
         x_range = self.x_range(mip=mip)
         y_range = self.y_range(mip=mip)
         return slice(*x_range), slice(*y_range), slice(*self.z)
-
-

--- a/corgie/cli/align.py
+++ b/corgie/cli/align.py
@@ -83,6 +83,8 @@ from corgie.cli.broadcast import BroadcastJob
 @corgie_option("--block_size", nargs=1, type=int, default=10)
 @corgie_option("--block_overlap", nargs=1, type=int, default=3)
 @corgie_option("--vote_dist", nargs=1, type=int, default=1)
+@corgie_option('--decay_dist', nargs=1, type=int, default=50)
+
 @click.pass_context
 def align(ctx,
           src_layer_spec,

--- a/corgie/cli/align.py
+++ b/corgie/cli/align.py
@@ -83,7 +83,7 @@ from corgie.cli.broadcast import BroadcastJob
     nargs=1,
     type=int,
     default=0,
-    help="0: block, 1: overlap, 2: stitch",
+    help="0: align blocks, 1: align overlaps, 2: vote over overlaps, 3: broadcast stitch field, 4: render with composed field",
 )
 @click.pass_context
 def align(
@@ -255,7 +255,6 @@ def align(
         corgie_logger.debug("Done!")
 
     if restart_stage <= 1:
-        corgie_logger.debug("Creating stitching fields...")
         corgie_logger.debug("Aligning stitching blocks...")
         for stitch_block in stitch_blocks:
             block_bcube = stitch_block.get_bcube(bcube)

--- a/corgie/cli/align.py
+++ b/corgie/cli/align.py
@@ -82,34 +82,32 @@ from corgie.cli.compare_sections import CompareSectionsJob
 @corgie_option("--block_overlap", nargs=1, type=int, default=3)
 @corgie_option("--vote_dist", nargs=1, type=int, default=1)
 @click.pass_context
-def align(
-    ctx,
-    src_layer_spec,
-    tgt_layer_spec,
-    dst_folder,
-    render_pad,
-    render_chunk_xy,
-    processor_spec,
-    pad,
-    crop,
-    processor_mip,
-    chunk_xy,
-    start_coord,
-    end_coord,
-    coord_mip,
-    bad_starter_path,
-    block_size,
-    block_overlap,
-    vote_dist,
-    blend_xy,
-    force_chunk_xy,
-    suffix,
-    copy_start,
-    seethrough_spec,
-    seethrough_spec_mip,
-):
+def align(ctx,
+          src_layer_spec,
+          tgt_layer_spec,
+          dst_folder,
+          render_pad,
+          render_chunk_xy,
+          processor_spec,
+          pad,
+          crop,
+          processor_mip,
+          chunk_xy,
+          start_coord,
+          end_coord,
+          coord_mip,
+          bad_starter_path,
+          block_size,
+          block_overlap,
+          vote_dist,
+          blend_xy,
+          force_chunk_xy,
+          suffix,
+          copy_start,
+          seethrough_spec,
+          seethrough_spec_mip):
 
-    scheduler = ctx.obj["scheduler"]
+    scheduler = ctx.obj['scheduler']
 
     if suffix is None:
         suffix = "_aligned"

--- a/corgie/cli/align.py
+++ b/corgie/cli/align.py
@@ -3,7 +3,7 @@ import os
 from corgie.block import get_blocks
 from copy import deepcopy
 
-from corgie import scheduling, argparsers, helpers, stack
+from corgie import exceptions
 
 from corgie.log import logger as corgie_logger
 from corgie.layers import get_layer_types, DEFAULT_LAYER_TYPE, str_to_layer_type
@@ -122,6 +122,13 @@ def align(
 
     if crop is None:
         crop = pad
+
+    corgie_logger.debug("Setting up layers...")
+    # TODO: store stitching images in layer other than even & odd
+    if (block_size - stitch_size) <= vote_dist:
+        raise exceptions.CorgieException(
+            "block_size too small for stitching + voting requirements (stitch_size + vote_dist)"
+        )
 
     corgie_logger.debug("Setting up layers...")
 

--- a/corgie/cli/align.py
+++ b/corgie/cli/align.py
@@ -3,7 +3,7 @@ import os
 from corgie.block import get_blocks
 from copy import deepcopy
 
-from corgie import exceptions
+from corgie import exceptions, stack, helpers, scheduling, argparsers
 
 from corgie.log import logger as corgie_logger
 from corgie.layers import get_layer_types, DEFAULT_LAYER_TYPE, str_to_layer_type

--- a/corgie/cli/align.py
+++ b/corgie/cli/align.py
@@ -125,7 +125,7 @@ def align(
 
     corgie_logger.debug("Setting up layers...")
     # TODO: store stitching images in layer other than even & odd
-    if (block_size - stitch_size) <= vote_dist:
+    if vote_dist + stitch_size - 2 >= block_size:
         raise exceptions.CorgieException(
             "block_size too small for stitching + voting requirements (stitch_size + vote_dist)"
         )

--- a/corgie/cli/align.py
+++ b/corgie/cli/align.py
@@ -187,7 +187,7 @@ def align(
     for block in blocks:
         corgie_logger.debug(block)
         corgie_logger.debug("stitch")
-        corgie_logger.debug(block.overlap(stitch_size, ""))
+        corgie_logger.debug(block.overlap(stitch_size))
 
     render_method = helpers.PartialSpecification(
         f=RenderJob,
@@ -261,7 +261,7 @@ def align(
         corgie_logger.debug("Creating stitching fields...")
         corgie_logger.debug("Aligning stitching blocks...")
         for block in blocks[1:]:
-            stitch_block = block.overlap(stitch_size, field_name)
+            stitch_block = block.overlap(stitch_size)
             block_bcube = stitch_block.get_bcube(bcube)
             align_block_job_forv = AlignBlockJob(
                 src_stack=stitch_block.src_stack,
@@ -288,12 +288,12 @@ def align(
                 "stitching_field", layer_type="field", overwrite=True
             )
             for block in blocks[1:]:
-                stitch_block = block.overlap(stitch_size, field_name)
+                stitch_block = block.overlap(stitch_size)
                 block_bcube = bcube.reset_coords(
                     zs=block.start, ze=block.start + 1, in_place=False
                 )
                 align_block_job_forv = VoteOverZJob(
-                    input_field=stitch_block.dst_stack[block_field],
+                    input_field=stitch_block.dst_stack[field_name],
                     output_field=stitching_field,
                     chunk_xy=chunk_xy,
                     bcube=block_bcube,

--- a/corgie/cli/align.py
+++ b/corgie/cli/align.py
@@ -371,7 +371,7 @@ def align(
             )
         if len(blocks) > 1:
             block_bcube = bcube.reset_coords(
-                zs=blocks[0].start, ze=blocks[-1].stop, in_place=False
+                zs=blocks[1].start, ze=blocks[-1].stop, in_place=False
             )
             src_stack.add_layer(composed_field)
             render_job = RenderJob(

--- a/corgie/cli/align.py
+++ b/corgie/cli/align.py
@@ -77,7 +77,7 @@ from corgie.cli.broadcast import BroadcastJob
     help="Number of sections involved in computing stitching fields.",
 )
 @corgie_option("--vote_dist", nargs=1, type=int, default=1)
-@corgie_option("--decay_dist", nargs=1, type=int, default=50)
+@corgie_option("--decay_dist", nargs=1, type=int, default=100)
 @corgie_option(
     "--restart_stage",
     nargs=1,

--- a/corgie/cli/align.py
+++ b/corgie/cli/align.py
@@ -67,17 +67,35 @@ from corgie.cli.broadcast import BroadcastJob
 @corgie_option("--end_coord", nargs=1, type=str, required=True)
 @corgie_option("--coord_mip", nargs=1, type=int, default=0)
 @corgie_optgroup("Block Alignment Specification")
-@corgie_option("--bad_starter_path", nargs=1, type=str, default=None)
+@corgie_option(
+    "--bad_starter_path",
+    nargs=1,
+    type=str,
+    default=None,
+    help="TODO: Filepath to list of sections that should not be used as the first section of any block.",
+)
 @corgie_option("--block_size", nargs=1, type=int, default=10)
 @corgie_option(
     "--stitch_size",
     nargs=1,
     type=int,
     default=3,
-    help="Number of sections involved in computing stitching fields.",
+    help="The number of sections used to compute stitching fields. If >1, then multiple stitching field estimates will be made, then corrected by voting.",
 )
-@corgie_option("--vote_dist", nargs=1, type=int, default=1)
-@corgie_option("--decay_dist", nargs=1, type=int, default=100)
+@corgie_option(
+    "--vote_dist",
+    nargs=1,
+    type=int,
+    default=1,
+    help="The number of previous sections for which fields will be estimated, then corrected by voting.",
+)
+@corgie_option(
+    "--decay_dist",
+    nargs=1,
+    type=int,
+    default=100,
+    help="The maximum distance in sections over which a previous section may influence a later one.",
+)
 @corgie_option(
     "--restart_stage",
     nargs=1,
@@ -290,14 +308,10 @@ def align(
 
     # Add in the stitch_estimated fields that were just created above
     even_stack.create_sublayer(
-        stitch_estimated_name,
-        layer_type="field",
-        overwrite=False,
+        stitch_estimated_name, layer_type="field", overwrite=False,
     )
     odd_stack.create_sublayer(
-        stitch_estimated_name,
-        layer_type="field",
-        overwrite=False,
+        stitch_estimated_name, layer_type="field", overwrite=False,
     )
     if restart_stage <= 2:
         if stitch_size > 1:
@@ -330,14 +344,10 @@ def align(
 
     # Add in the block-align fields
     even_stack.create_sublayer(
-        block_field_name,
-        layer_type="field",
-        overwrite=False,
+        block_field_name, layer_type="field", overwrite=False,
     )
     odd_stack.create_sublayer(
-        block_field_name,
-        layer_type="field",
-        overwrite=False,
+        block_field_name, layer_type="field", overwrite=False,
     )
     composed_field = dst_stack.create_sublayer(
         f"composed_field{suffix}", layer_type="field", overwrite=True

--- a/corgie/cli/align_block.py
+++ b/corgie/cli/align_block.py
@@ -29,7 +29,6 @@ class AlignBlockJob(scheduling.Job):
     def __init__(
         self,
         src_stack,
-        tgt_stack,
         dst_stack,
         cf_method,
         render_method,
@@ -51,7 +50,6 @@ class AlignBlockJob(scheduling.Job):
             resume_stage (int): indicates stage (compute field/vote/render)
         """
         self.src_stack = src_stack
-        self.tgt_stack = tgt_stack
         self.dst_stack = dst_stack
         self.bcube = bcube
         self.seethrough_method = seethrough_method
@@ -352,17 +350,6 @@ class AlignBlockJob(scheduling.Job):
     help="Source layer spec. Use multiple times to include all masks, fields, images. "
     + LAYER_HELP_STR,
 )
-#
-@corgie_option(
-    "--tgt_layer_spec",
-    "-t",
-    nargs=1,
-    type=str,
-    required=False,
-    multiple=True,
-    help="Target layer spec. Use multiple times to include all masks, fields, images. \n"
-    "DEFAULT: Same as source layers",
-)
 @corgie_option(
     "--dst_folder",
     nargs=1,
@@ -401,7 +388,6 @@ class AlignBlockJob(scheduling.Job):
 def align_block(
     ctx,
     src_layer_spec,
-    tgt_layer_spec,
     dst_folder,
     vote_dist,
     resume_index,
@@ -437,10 +423,6 @@ def align_block(
     corgie_logger.debug("Setting up layers...")
     src_stack = create_stack_from_spec(src_layer_spec, name="src", readonly=True)
     src_stack.folder = dst_folder
-
-    tgt_stack = create_stack_from_spec(
-        tgt_layer_spec, name="tgt", readonly=True, reference=src_stack
-    )
 
     force_chunk_xy = chunk_xy if force_chunk_xy else None
     dst_stack = stack.create_stack_from_reference(
@@ -496,7 +478,6 @@ def align_block(
 
         align_block_job_back = AlignBlockJob(
             src_stack=src_stack,
-            tgt_stack=tgt_stack,
             dst_stack=dst_stack,
             bcube=bcube_back,
             render_method=render_method,
@@ -515,7 +496,6 @@ def align_block(
 
         align_block_job_forv = AlignBlockJob(
             src_stack=src_stack,
-            tgt_stack=tgt_stack,
             dst_stack=deepcopy(dst_stack),
             bcube=bcube_forv,
             render_method=render_method,
@@ -534,7 +514,6 @@ def align_block(
     else:
         align_block_job = AlignBlockJob(
             src_stack=src_stack,
-            tgt_stack=tgt_stack,
             dst_stack=dst_stack,
             bcube=bcube,
             render_method=render_method,

--- a/corgie/cli/align_block.py
+++ b/corgie/cli/align_block.py
@@ -26,22 +26,24 @@ from corgie.cli.upsample import UpsampleJob
 
 
 class AlignBlockJob(scheduling.Job):
-    def __init__(self,
-                src_stack,
-                tgt_stack,
-                dst_stack,
-                cf_method,
-                render_method,
-                bcube,
-                seethrough_method=None,
-                copy_start=True,
-                backward=False,
-                vote_dist=1,
-                suffix=None,
-                softmin_temp=None,
-                blur_sigma=1.,
-                resume_index=0,
-                resume_stage=0):
+    def __init__(
+        self,
+        src_stack,
+        tgt_stack,
+        dst_stack,
+        cf_method,
+        render_method,
+        bcube,
+        seethrough_method=None,
+        copy_start=True,
+        backward=False,
+        vote_dist=1,
+        suffix=None,
+        softmin_temp=None,
+        blur_sigma=1.0,
+        resume_index=0,
+        resume_stage=0,
+    ):
         """Align block with and without voting
 
         Args:
@@ -73,11 +75,11 @@ class AlignBlockJob(scheduling.Job):
         if not self.backward:
             z_step = 1
             z_start = self.bcube.z_range()[0]
-            z_end = self.bcube.z_range()[1] + z_step
+            z_end = self.bcube.z_range()[1]
         else:
             z_step = -1
             z_start = self.bcube.z_range()[1]
-            z_end = self.bcube.z_range()[0] + z_step
+            z_end = self.bcube.z_range()[0]
         seethrough_offset = -z_step
 
         # Set up voting layers
@@ -242,18 +244,19 @@ class AlignBlockJob(scheduling.Job):
 
                 if (z_resume != z) or (self.resume_stage < 2):
                     if self.vote_dist > 1:
-                        corgie_logger.debug(f'Vote {z}')
-                        chunk_xy = self.cf_method['chunk_xy']
-                        chunk_z = self.cf_method['chunk_z']
-                        mip = self.cf_method['processor_mip'][0]
+                        corgie_logger.debug(f"Vote {z}")
+                        chunk_xy = self.cf_method["chunk_xy"]
+                        chunk_z = self.cf_method["chunk_z"]
+                        mip = self.cf_method["processor_mip"][0]
                         vote_job = VoteOverFieldsJob(
-                                        input_fields=estimated_fields,
-                                        output_field=final_field,
-                                        chunk_xy=chunk_xy,
-                                        bcube=bcube,
-                                        mip=mip,
-                                        softmin_temp=self.softmin_temp,
-                                        blur_sigma=self.blur_sigma)
+                            input_fields=estimated_fields,
+                            output_field=final_field,
+                            chunk_xy=chunk_xy,
+                            bcube=bcube,
+                            mip=mip,
+                            softmin_temp=self.softmin_temp,
+                            blur_sigma=self.blur_sigma,
+                        )
 
                         yield from vote_job.task_generator
                         yield scheduling.wait_until_done

--- a/corgie/cli/align_block.py
+++ b/corgie/cli/align_block.py
@@ -130,7 +130,11 @@ class AlignBlockJob(scheduling.Job):
                 yield from render_job.task_generator
                 yield scheduling.wait_until_done
             # CREATE STARTER SECTIONS FOR VOTING
-            elif (z_step > 0 and z < z_start) or (z_step < 0 and z > z_start):
+            elif (
+                (z_step > 0 and z < z_start)
+                or (z_step < 0 and z > z_start)
+                and self.copy_start
+            ):
                 corgie_logger.debug(f"Compute field vote starter {z_start}<{z}")
                 offset = z_start - z
                 compute_field_job = self.cf_method(

--- a/corgie/cli/align_block.py
+++ b/corgie/cli/align_block.py
@@ -79,7 +79,7 @@ class AlignBlockJob(scheduling.Job):
 
         # Set up voting layers
         if (self.vote_dist > 1) and self.use_starters:
-            starter_section_start = z_start - self.vote_dist * z_step
+            starter_section_start = z_start - (self.vote_dist - 1) * z_step
         else:
             starter_section_start = z_start
         z_range = range(starter_section_start, z_end, z_step)

--- a/corgie/cli/align_block.py
+++ b/corgie/cli/align_block.py
@@ -17,7 +17,7 @@ from corgie.argparsers import (
 
 from corgie.cli.render import RenderJob
 from corgie.cli.copy import CopyJob
-from corgie.cli.vote import VoteJob
+from corgie.cli.vote import VoteOverFieldsJob
 from corgie.cli.compute_field import ComputeFieldJob
 from corgie.cli.compare_sections import CompareSectionsJob
 
@@ -26,24 +26,22 @@ from corgie.cli.upsample import UpsampleJob
 
 
 class AlignBlockJob(scheduling.Job):
-    def __init__(
-        self,
-        src_stack,
-        tgt_stack,
-        dst_stack,
-        cf_method,
-        render_method,
-        bcube,
-        seethrough_method=None,
-        copy_start=True,
-        backward=False,
-        vote_dist=1,
-        suffix=None,
-        softmin_temp=1,
-        blur_sigma=1,
-        resume_index=0,
-        resume_stage=0,
-    ):
+    def __init__(self,
+                src_stack,
+                tgt_stack,
+                dst_stack,
+                cf_method,
+                render_method,
+                bcube,
+                seethrough_method=None,
+                copy_start=True,
+                backward=False,
+                vote_dist=1,
+                suffix=None,
+                softmin_temp=None,
+                blur_sigma=1.,
+                resume_index=0,
+                resume_stage=0):
         """Align block with and without voting
 
         Args:
@@ -244,20 +242,18 @@ class AlignBlockJob(scheduling.Job):
 
                 if (z_resume != z) or (self.resume_stage < 2):
                     if self.vote_dist > 1:
-                        corgie_logger.debug(f"Vote {z}")
-                        chunk_xy = self.cf_method["chunk_xy"]
-                        chunk_z = self.cf_method["chunk_z"]
-                        mip = self.cf_method["processor_mip"][0]
-                        vote_job = VoteJob(
-                            input_fields=estimated_fields,
-                            output_field=final_field,
-                            chunk_xy=chunk_xy,
-                            chunk_z=chunk_z,
-                            bcube=bcube,
-                            mip=mip,
-                            softmin_temp=self.softmin_temp,
-                            blur_sigma=self.blur_sigma,
-                        )
+                        corgie_logger.debug(f'Vote {z}')
+                        chunk_xy = self.cf_method['chunk_xy']
+                        chunk_z = self.cf_method['chunk_z']
+                        mip = self.cf_method['processor_mip'][0]
+                        vote_job = VoteOverFieldsJob(
+                                        input_fields=estimated_fields,
+                                        output_field=final_field,
+                                        chunk_xy=chunk_xy,
+                                        bcube=bcube,
+                                        mip=mip,
+                                        softmin_temp=self.softmin_temp,
+                                        blur_sigma=self.blur_sigma)
 
                         yield from vote_job.task_generator
                         yield scheduling.wait_until_done

--- a/corgie/cli/broadcast.py
+++ b/corgie/cli/broadcast.py
@@ -1,25 +1,36 @@
-import torch
+from copy import deepcopy
 from math import log
 from corgie.log import logger as corgie_logger
-from corgie import scheduling, argparsers, helpers, stack
+from corgie import scheduling, helpers
 from corgie.stack import DistanceFieldSet
 
 
 class BroadcastJob(scheduling.Job):
     def __init__(
-        self, input_fields, output_field, chunk_xy, bcube, pad, z_list, mip, decay_dist
+        self,
+        block_field,
+        stitching_fields,
+        output_field,
+        chunk_xy,
+        bcube,
+        pad,
+        z_list,
+        mip,
+        decay_dist,
     ):
         """
         Args:
-            input_fields ([Layers]): collection of fields
+            block_field (Layer): final field
+            stitching_fields ([Layers]): collection of fields that will warp in order
             output_field (Layer)
             mip (int)
             bcube (BoundingCube)
             pad (int)
-            z_list ([int]): list of z indices
+            z_list ([int]): list of z indices where stitching_fields should be sampled
             decay_dist (float): distance for influence of previous section
         """
-        self.input_fields = input_fields
+        self.block_field = block_field
+        self.stitching_fields = stitching_fields
         self.output_field = output_field
         self.chunk_xy = chunk_xy
         self.bcube = bcube
@@ -30,21 +41,20 @@ class BroadcastJob(scheduling.Job):
         super().__init__()
 
     def task_generator(self):
-        tmp_layer = self.input_fields[0]
-        chunks = tmp_layer.break_bcube_into_chunks(
+        chunks = self.output_field.break_bcube_into_chunks(
             bcube=self.bcube, chunk_xy=self.chunk_xy, chunk_z=1, mip=self.mip
         )
 
         tasks = []
         for chunk in chunks:
-            z_list = self.z_list + [chunk.z_range()[0]]
             task = BroadcastTask(
-                input_fields=self.input_fields,
+                block_field=self.block_field,
+                stitching_fields=self.stitching_fields,
                 output_field=self.output_field,
                 mip=self.mip,
                 bcube=chunk,
                 pad=self.pad,
-                z_list=z_list,
+                z_list=self.z_list,
                 decay_dist=self.decay_dist,
             )
             tasks.append(task)
@@ -55,16 +65,12 @@ class BroadcastJob(scheduling.Job):
         yield tasks
 
 
-class BroadcastTask(scheduling.Task):
+class ComposeWithDistanceTask(scheduling.Task):
     def __init__(self, input_fields, output_field, mip, bcube, pad, z_list, decay_dist):
         """Compose set of fields, adjusted by distance
 
         Order of fields are from target to source, e.g.
             $f_{0 \leftarrow 2} \circ f_{2 \leftarrow 3}$ : [0, 2, 3]
-
-        If len(input_fields) < len(z_list), then repeat input_fields. For
-        example, we might only pass a single field, or only the even and odd
-        block fields.
 
         Args:
             input_fields ([Layers]): collection of fields
@@ -76,7 +82,7 @@ class BroadcastTask(scheduling.Task):
             decay_dist (float): distance for influence of previous section
         """
         super().__init__()
-        self.input_fields = input_fields[::-1]
+        self.input_fields = input_fields
         self.output_field = output_field
         self.mip = mip
         self.pad = pad
@@ -85,16 +91,8 @@ class BroadcastTask(scheduling.Task):
         self.decay_dist = decay_dist
         self.trans_adj = helpers.percentile_trans_adjuster
 
-        if len(z_list) != len(self.input_fields):
-            fmul = len(z_list) // len(input_fields)
-            frem = len(z_list) % len(input_fields)
-            input_fields = input_fields[::-1]
-            input_fields = fmul * input_fields + input_fields[:frem]
-            input_fields = input_fields[::-1]
-        self.input_fields = input_fields
-
     def execute(self):
-        corgie_logger.debug(f"BroadcastTask, {self.bcube}")
+        corgie_logger.debug(f"ComposeWithDistanceTask, {self.bcube}")
         corgie_logger.debug(f"input_fields: {self.input_fields}")
         corgie_logger.debug(f"z_list: {self.z_list}")
         pbcube = self.bcube.uncrop(self.pad, self.mip)
@@ -102,3 +100,50 @@ class BroadcastTask(scheduling.Task):
         field = fields.read(bcube=pbcube, z_list=self.z_list, mip=self.mip)
         cropped_field = helpers.crop(field, self.pad)
         self.output_field.write(cropped_field, bcube=self.bcube, mip=self.mip)
+
+
+class BroadcastTask(ComposeWithDistanceTask):
+    def __init__(
+        self,
+        block_field,
+        stitching_fields,
+        output_field,
+        mip,
+        bcube,
+        pad,
+        z_list,
+        decay_dist,
+    ):
+        """Compose set of stitching_fields, adjusted by distance, with block_field.
+
+        Args:
+            block_field (Layer): most recent field, that last to be warped
+            stitching_fields ([Layers]): collection of fields at stitching interfaces,
+                which are assumed to alternate
+            output_field (Layer)
+            mip (int)
+            bcube (BoundingCube): xy location of where to sample all fields;
+                z location of where to sample block_field and where to write composed field
+            pad (int)
+            z_list ([int]): list of z locations for where to sample each stitching_field;
+                length of z_list will indicate how many times to repeat the stitching_fields list
+            decay_dist (float): distance for influence of previous section
+        """
+        corgie_logger.debug(f"z_list: {z_list}")
+        corgie_logger.debug(f"stitching_fields: {stitching_fields}")
+        input_fields = stitching_fields[::-1]
+        if len(z_list) != len(input_fields):
+            fmul = len(z_list) // len(input_fields)
+            frem = len(z_list) % len(input_fields)
+            input_fields = input_fields[::-1]
+            input_fields = fmul * input_fields + input_fields[:frem]
+            input_fields = input_fields[::-1]
+        super().__init__(
+            input_fields=input_fields + [block_field],
+            output_field=output_field,
+            mip=mip,
+            pad=pad,
+            bcube=bcube,
+            z_list=z_list + [bcube.z_range()[0]],
+            decay_dist=decay_dist,
+        )

--- a/corgie/cli/broadcast.py
+++ b/corgie/cli/broadcast.py
@@ -1,0 +1,136 @@
+import torch
+from math import log
+from corgie.log import logger as corgie_logger
+from corgie import scheduling, argparsers, helpers, stack
+
+class BroadcastJob(scheduling.Job):
+    def __init__(self,
+                 input_fields,
+                 output_field,
+                 chunk_xy,
+                 bcube,
+                 pad,
+                 z_list,
+                 mip,
+                 decay_dist):
+        self.input_fields     = input_fields   
+        self.output_field     = output_field
+        self.chunk_xy         = chunk_xy
+        self.bcube            = bcube
+        self.pad              = pad
+        self.z_list           = z_list
+        self.mip              = mip
+        self.decay_dist       = decay_dist
+        super().__init__()
+
+    def task_generator(self):
+        tmp_key = list(self.input_fields.keys())[0]
+        tmp_layer = self.input_fields[tmp_key]
+        chunks = tmp_layer.break_bcube_into_chunks(
+                    bcube=self.bcube,
+                    chunk_xy=self.chunk_xy,
+                    chunk_z=1,
+                    mip=self.mip)
+
+        tasks = [BroadcastTask(input_fields=self.input_fields,
+                            output_field=self.output_field,
+                            mip=self.mip,
+                            bcube=chunk,
+                            pad=self.pad,
+                            z_list=self.z_list, 
+                            decay_dist=self.decay_dist) for chunk in chunks]
+
+        corgie_logger.debug("Yielding BroadcastTask for bcube: {}, MIP: {}".format(
+                                self.bcube, self.mip))
+        yield tasks
+
+class BroadcastTask(scheduling.Task):
+    def __init__(self, 
+                 input_fields, 
+                 output_field, 
+                 mip,
+                 bcube,
+                 pad,
+                 z_list,
+                 decay_dist):
+        """Compose set of fields, adjusted by distance 
+
+        Order of fields are from target to source, e.g.
+            $f_{0 \leftarrow 2} \circ f_{2 \leftarrow 3}$ : [0, 2, 3]
+
+        If len(input_fields) < len(z_list), then repeat input_fields. For
+        example, we might only pass a single field, or only the even and odd
+        block fields.
+        
+        Args:
+            input_fields ([Layers]): collection of fields
+            output_field (Layer)
+            mip (int)
+            bcube (BoundingCube)
+            pad (int)
+            z_list ([int]): list of z indices
+            decay_dist (float): distance for influence of previous section
+        """
+        super().__init__()
+        self.input_fields     = input_fields
+        self.output_field     = output_field
+        self.mip              = mip
+        self.pad              = pad
+        self.bcube            = bcube
+        self.z_list           = z_list
+        self.decay_dist       = decay_dist
+        self.trans_adj        = helpers.percentile_trans_adjuster
+
+        field_multiple = len(self.z_list) // len(self.input_fields)
+        if field_multiple > 1:
+            self.input_fields = field_multiple * self.input_fields
+
+    def adjust_bcube(self, bcube, z):
+        return bcube.reset_coords(zs=z, ze=z+1, inplace=False)
+
+    def get_field(self, layer, bcube, mip, dist):
+        """Get field, adjusted by distance
+
+        Args:
+            layer (Layer)
+            bcube (BoundingCube)
+            mip (int)
+            dist (float)
+        
+        Returns:
+            TorchField adjusted (blurred/attenuated) by distance
+        """
+        # TODO: add ability to get blurred field using trilinear interpolation
+        c = min(max(dist / self.decay_dist, 0.), 1.)
+        f = layer.read(bcube=bcube, mip=mip).field_()
+        return f * c
+
+    def execute(self):
+        pbcube = self.bcube.uncrop(self.pad, self.mip)
+        src_z = self.z_list[-1]
+        z = self.z_list[0]
+        layer = self.input_fields[0]
+        abcube = self.adjust_bcube(pbcube, z)
+        agg_field = self.get_field(layer=layer,
+                                    bcube=abcube,
+                                    mip=self.mip,
+                                    dist=src_z - z)
+        for z, layer in zip(self.z_list[1:], self.input_fields[1:]):
+            trans = helpers.percentile_trans_adjuster(agg_field)
+            trans.x = (trans.x // (2**self.mip)) * 2**self.mip
+            trans.y = (trans.y // (2**self.mip)) * 2**self.mip
+            abcube = self.adjust_bcube(pbcube, z)
+            abcube = abcube.translate(x_offset=int(trans.x),
+                                      y_offset=int(trans.y))
+            agg_field -= trans
+            agg_field = agg_field.from_pixels()
+            this_field = self.get_field(layer=layer,
+                                        bcube=abcube,
+                                        mip=self.mip,
+                                        dist=src_z - z)
+            this_field = this_field.from_pixels()
+            agg_field = agg_field(this_field)
+            agg_field = agg_field.pixels()
+            agg_field += trans
+        cropped_field = helpers.crop(agg_field, self.pad)
+        self.output_field.write(cropped_field, bcube=self.bcube, mip=self.mip)

--- a/corgie/cli/broadcast.py
+++ b/corgie/cli/broadcast.py
@@ -2,58 +2,62 @@ import torch
 from math import log
 from corgie.log import logger as corgie_logger
 from corgie import scheduling, argparsers, helpers, stack
+from corgie.stack import DistanceFieldSet
+
 
 class BroadcastJob(scheduling.Job):
-    def __init__(self,
-                 input_fields,
-                 output_field,
-                 chunk_xy,
-                 bcube,
-                 pad,
-                 z_list,
-                 mip,
-                 decay_dist):
-        self.input_fields     = input_fields   
-        self.output_field     = output_field
-        self.chunk_xy         = chunk_xy
-        self.bcube            = bcube
-        self.pad              = pad
-        self.z_list           = z_list
-        self.mip              = mip
-        self.decay_dist       = decay_dist
+    def __init__(
+        self, input_fields, output_field, chunk_xy, bcube, pad, z_list, mip, decay_dist
+    ):
+        """
+        Args:
+            input_fields ([Layers]): collection of fields
+            output_field (Layer)
+            mip (int)
+            bcube (BoundingCube)
+            pad (int)
+            z_list ([int]): list of z indices
+            decay_dist (float): distance for influence of previous section
+        """
+        self.input_fields = input_fields
+        self.output_field = output_field
+        self.chunk_xy = chunk_xy
+        self.bcube = bcube
+        self.pad = pad
+        self.z_list = z_list
+        self.mip = mip
+        self.decay_dist = decay_dist
         super().__init__()
 
     def task_generator(self):
-        tmp_key = list(self.input_fields.keys())[0]
-        tmp_layer = self.input_fields[tmp_key]
+        tmp_layer = self.input_fields[0]
         chunks = tmp_layer.break_bcube_into_chunks(
-                    bcube=self.bcube,
-                    chunk_xy=self.chunk_xy,
-                    chunk_z=1,
-                    mip=self.mip)
+            bcube=self.bcube, chunk_xy=self.chunk_xy, chunk_z=1, mip=self.mip
+        )
 
-        tasks = [BroadcastTask(input_fields=self.input_fields,
-                            output_field=self.output_field,
-                            mip=self.mip,
-                            bcube=chunk,
-                            pad=self.pad,
-                            z_list=self.z_list, 
-                            decay_dist=self.decay_dist) for chunk in chunks]
+        tasks = []
+        for chunk in chunks:
+            z_list = self.z_list + [chunk.z_range()[0]]
+            task = BroadcastTask(
+                input_fields=self.input_fields,
+                output_field=self.output_field,
+                mip=self.mip,
+                bcube=chunk,
+                pad=self.pad,
+                z_list=z_list,
+                decay_dist=self.decay_dist,
+            )
+            tasks.append(task)
 
-        corgie_logger.debug("Yielding BroadcastTask for bcube: {}, MIP: {}".format(
-                                self.bcube, self.mip))
+        corgie_logger.debug(
+            "Yielding BroadcastTask for bcube: {}, MIP: {}".format(self.bcube, self.mip)
+        )
         yield tasks
 
+
 class BroadcastTask(scheduling.Task):
-    def __init__(self, 
-                 input_fields, 
-                 output_field, 
-                 mip,
-                 bcube,
-                 pad,
-                 z_list,
-                 decay_dist):
-        """Compose set of fields, adjusted by distance 
+    def __init__(self, input_fields, output_field, mip, bcube, pad, z_list, decay_dist):
+        """Compose set of fields, adjusted by distance
 
         Order of fields are from target to source, e.g.
             $f_{0 \leftarrow 2} \circ f_{2 \leftarrow 3}$ : [0, 2, 3]
@@ -61,7 +65,7 @@ class BroadcastTask(scheduling.Task):
         If len(input_fields) < len(z_list), then repeat input_fields. For
         example, we might only pass a single field, or only the even and odd
         block fields.
-        
+
         Args:
             input_fields ([Layers]): collection of fields
             output_field (Layer)
@@ -72,65 +76,29 @@ class BroadcastTask(scheduling.Task):
             decay_dist (float): distance for influence of previous section
         """
         super().__init__()
-        self.input_fields     = input_fields
-        self.output_field     = output_field
-        self.mip              = mip
-        self.pad              = pad
-        self.bcube            = bcube
-        self.z_list           = z_list
-        self.decay_dist       = decay_dist
-        self.trans_adj        = helpers.percentile_trans_adjuster
+        self.input_fields = input_fields[::-1]
+        self.output_field = output_field
+        self.mip = mip
+        self.pad = pad
+        self.bcube = bcube
+        self.z_list = z_list
+        self.decay_dist = decay_dist
+        self.trans_adj = helpers.percentile_trans_adjuster
 
-        field_multiple = len(self.z_list) // len(self.input_fields)
-        if field_multiple > 1:
-            self.input_fields = field_multiple * self.input_fields
-
-    def adjust_bcube(self, bcube, z):
-        return bcube.reset_coords(zs=z, ze=z+1, inplace=False)
-
-    def get_field(self, layer, bcube, mip, dist):
-        """Get field, adjusted by distance
-
-        Args:
-            layer (Layer)
-            bcube (BoundingCube)
-            mip (int)
-            dist (float)
-        
-        Returns:
-            TorchField adjusted (blurred/attenuated) by distance
-        """
-        # TODO: add ability to get blurred field using trilinear interpolation
-        c = min(max(dist / self.decay_dist, 0.), 1.)
-        f = layer.read(bcube=bcube, mip=mip).field_()
-        return f * c
+        if len(z_list) != len(self.input_fields):
+            fmul = len(z_list) // len(input_fields)
+            frem = len(z_list) % len(input_fields)
+            input_fields = input_fields[::-1]
+            input_fields = fmul * input_fields + input_fields[:frem]
+            input_fields = input_fields[::-1]
+        self.input_fields = input_fields
 
     def execute(self):
+        corgie_logger.debug(f"BroadcastTask, {self.bcube}")
+        corgie_logger.debug(f"input_fields: {self.input_fields}")
+        corgie_logger.debug(f"z_list: {self.z_list}")
         pbcube = self.bcube.uncrop(self.pad, self.mip)
-        src_z = self.z_list[-1]
-        z = self.z_list[0]
-        layer = self.input_fields[0]
-        abcube = self.adjust_bcube(pbcube, z)
-        agg_field = self.get_field(layer=layer,
-                                    bcube=abcube,
-                                    mip=self.mip,
-                                    dist=src_z - z)
-        for z, layer in zip(self.z_list[1:], self.input_fields[1:]):
-            trans = helpers.percentile_trans_adjuster(agg_field)
-            trans.x = (trans.x // (2**self.mip)) * 2**self.mip
-            trans.y = (trans.y // (2**self.mip)) * 2**self.mip
-            abcube = self.adjust_bcube(pbcube, z)
-            abcube = abcube.translate(x_offset=int(trans.x),
-                                      y_offset=int(trans.y))
-            agg_field -= trans
-            agg_field = agg_field.from_pixels()
-            this_field = self.get_field(layer=layer,
-                                        bcube=abcube,
-                                        mip=self.mip,
-                                        dist=src_z - z)
-            this_field = this_field.from_pixels()
-            agg_field = agg_field(this_field)
-            agg_field = agg_field.pixels()
-            agg_field += trans
-        cropped_field = helpers.crop(agg_field, self.pad)
+        fields = DistanceFieldSet(decay_dist=self.decay_dist, layers=self.input_fields)
+        field = fields.read(bcube=pbcube, z_list=self.z_list, mip=self.mip)
+        cropped_field = helpers.crop(field, self.pad)
         self.output_field.write(cropped_field, bcube=self.bcube, mip=self.mip)

--- a/corgie/cli/broadcast.py
+++ b/corgie/cli/broadcast.py
@@ -149,7 +149,8 @@ class BroadcastTask(scheduling.Task):
             input_fields = input_fields[::-1]
             input_fields = fmul * input_fields + input_fields[:frem]
             input_fields = input_fields[::-1]
-        z_list = (self.z_list + [self.bcube.z_range()[0]],)
+        input_fields += [self.block_field]
+        z_list = self.z_list + [self.bcube.z_range()[0]]
         corgie_logger.debug(f"input_fields: {input_fields}")
         corgie_logger.debug(f"z_list: {z_list}")
         pbcube = self.bcube.uncrop(self.pad, self.mip)

--- a/corgie/cli/compute_field.py
+++ b/corgie/cli/compute_field.py
@@ -1,7 +1,7 @@
 import click
 import procspec
 
-from corgie import scheduling, argparsers, helpers
+from corgie import scheduling, argparsers, helpers, exceptions
 
 from corgie.log import logger as corgie_logger
 from corgie.layers import get_layer_types, DEFAULT_LAYER_TYPE, str_to_layer_type

--- a/corgie/cli/copy.py
+++ b/corgie/cli/copy.py
@@ -95,6 +95,12 @@ class CopyTask(scheduling.Task):
                 src[mask] = 0
             l.write(src, bcube=self.bcube, mip=self.mip)
 
+        # copy fields
+        write_layers = self.dst_stack.get_layers_of_type("field")
+        for l in write_layers:
+            src = src_data_dict[f"src_{l.name}"]
+            l.write(src, bcube=self.bcube, mip=self.mip)
+
 
 @click.command()
 @corgie_optgroup("Layer Parameters")

--- a/corgie/cli/render.py
+++ b/corgie/cli/render.py
@@ -208,6 +208,10 @@ class RenderTask(scheduling.Task):
 
             l.write(cropped_out, bcube=self.bcube, mip=self.mip)
 
+        for f in self.additional_fields:
+            # remove fields we added
+            self.src_stack.remove_layer(f.name)
+
 
 @click.command()
 @corgie_optgroup("Layer Parameters")

--- a/corgie/cli/seethrough_block.py
+++ b/corgie/cli/seethrough_block.py
@@ -17,7 +17,6 @@ from corgie.argparsers import (
 
 from corgie.cli.render import RenderJob
 from corgie.cli.copy import CopyJob
-from corgie.cli.vote import VoteJob
 from corgie.cli.compute_field import ComputeFieldJob
 from corgie.cli.compare_sections import CompareSectionsJob
 
@@ -163,7 +162,11 @@ def seethrough_block(
         force_chunk_z=force_chunk_z,
     )
     render_method = helpers.PartialSpecification(
-        f=RenderJob, pad=pad, chunk_xy=chunk_xy, chunk_z=1, render_masks=False,
+        f=RenderJob,
+        pad=pad,
+        chunk_xy=chunk_xy,
+        chunk_z=1,
+        render_masks=False,
     )
     seethrough_method = helpers.PartialSpecification(
         f=CompareSectionsJob,
@@ -194,4 +197,3 @@ def seethrough_block(
         f"Results in {[str(l) for l in dst_stack.get_layers_of_type('img')]}"
     )
     corgie_logger.info(result_report)
-

--- a/corgie/cli/vote.py
+++ b/corgie/cli/vote.py
@@ -1,62 +1,75 @@
 import torch
+from math import log
 from corgie.log import logger as corgie_logger
 from corgie import scheduling, argparsers, helpers, stack
 
+def compute_softmin_temp(dist, weight, size):
+    """Compute softmin temp given binary assumptions
 
-class VoteJob(scheduling.Job):
-    def __init__(
-        self,
-        input_fields,
-        output_field,
-        chunk_xy,
-        chunk_z,
-        bcube,
-        mip,
-        softmin_temp,
-        blur_sigma,
-    ):
-        self.input_fields = input_fields
-        self.output_field = output_field
-        self.chunk_xy = chunk_xy
-        self.chunk_z = chunk_z
-        self.bcube = bcube
-        self.mip = mip
-        self.softmin_temp = softmin_temp
-        self.blur_sigma = blur_sigma
+    Assumes that voting subsets are either correct or incorrect.
+
+    Args:
+        dist (float): distance between the average differences of 
+            a correct and incorrect subset.
+        weight (float): desired weight to be assigned for correct/incorrect
+            distance.
+        size (int): size of a subset in voting
+
+    Returns:
+        float for softmin temperature that will achieve this weight
+    """
+    return -dist / (log(1-weight) - log(weight*size))
+
+class VoteOverFieldsJob(scheduling.Job):
+    def __init__(self,
+                 input_fields,
+                 output_field,
+                 chunk_xy,
+                 bcube,
+                 mip,
+                 softmin_temp=None,
+                 blur_sigma=1.):
+        self.input_fields     = input_fields   
+        self.output_field     = output_field
+        self.chunk_xy         = chunk_xy
+        self.bcube            = bcube
+        self.mip              = mip
+        self.softmin_temp     = softmin_temp 
+        self.blur_sigma       = blur_sigma
         super().__init__()
 
     def task_generator(self):
         tmp_key = list(self.input_fields.keys())[0]
         tmp_layer = self.input_fields[tmp_key]
         chunks = tmp_layer.break_bcube_into_chunks(
-            bcube=self.bcube, chunk_xy=self.chunk_xy, chunk_z=self.chunk_z, mip=self.mip
-        )
+                    bcube=self.bcube,
+                    chunk_xy=self.chunk_xy,
+                    chunk_z=1,
+                    mip=self.mip)
 
-        tasks = [
-            VoteTask(
-                input_fields=self.input_fields,
-                output_field=self.output_field,
-                mip=self.mip,
-                bcube=chunk,
-                softmin_temp=self.softmin_temp,
-                blur_sigma=self.blur_sigma,
-            )
-            for chunk in chunks
-        ]
+        tasks = [VoteOverFieldsTask(input_fields=self.input_fields,
+                            output_field=self.output_field,
+                            mip=self.mip,
+                            bcube=chunk,
+                            softmin_temp=self.softmin_temp,
+                            blur_sigma=self.blur_sigma) for chunk in chunks]
 
         corgie_logger.debug(
             "Yielding VoteTask for bcube: {}, MIP: {}".format(self.bcube, self.mip)
         )
         yield tasks
 
-
-class VoteTask(scheduling.Task):
-    def __init__(
-        self, input_fields, output_field, mip, bcube, softmin_temp, blur_sigma
-    ):
-        """Find median vector for each location is set of fields
-
-        Notes:
+class VoteOverFieldsTask(scheduling.Task):
+    def __init__(self, 
+                 input_fields, 
+                 output_field, 
+                 mip,
+                 bcube,
+                 softmin_temp,
+                 blur_sigma=1.):
+        """Find median vector for single location over set of fields 
+        
+        Notes: 
             Does not ignore identity fields.
             Padding & cropping is not necessary.
 
@@ -64,23 +77,115 @@ class VoteTask(scheduling.Task):
             input_fields (Stack): collection of fields
             output_field (Layer)
             mip (int)
-            bcbue (BoundingCube)
+            bcube (BoundingCube)
         """
         super().__init__()
-        self.input_fields = input_fields
-        self.output_field = output_field
-        self.mip = mip
-        self.bcube = bcube
-        self.softmin_temp = softmin_temp
-        self.blur_sigma = blur_sigma
+        self.input_fields     = input_fields
+        self.output_field     = output_field
+        self.mip              = mip
+        self.bcube            = bcube
+        if softmin_temp is None:
+            softmin_temp = compute_softmin_temp(dist=1,
+                                                weight=0.99, 
+                                                size=len(input_fields))
+        self.softmin_temp     = softmin_temp 
+        self.blur_sigma       = blur_sigma
 
     def execute(self):
-        z = self.bcube.z[0]
         bcube = self.bcube
         mip = self.mip
         fields = [f.read(bcube, mip=mip) for f in self.input_fields.values()]
         fields = torch.cat([f for f in fields]).field()
-        voted_field = fields.vote(
-            softmin_temp=self.softmin_temp, blur_sigma=self.blur_sigma
-        )
-        self.output_field.write(data_tens=voted_field, bcube=bcube, mip=self.mip)
+        voted_field = fields.vote(softmin_temp=self.softmin_temp,
+                                  blur_sigma=self.blur_sigma)
+        self.output_field.write(data_tens=voted_field, 
+                                    bcube=bcube, 
+                                    mip=self.mip)
+
+class VoteOverZJob(scheduling.Job):
+    def __init__(self,
+                 input_field,
+                 output_field,
+                 chunk_xy,
+                 bcube,
+                 z_list,
+                 mip,
+                 softmin_temp=None,
+                 blur_sigma=1.):
+        self.input_field      = input_field   
+        self.output_field     = output_field
+        self.chunk_xy         = chunk_xy
+        self.bcube            = bcube
+        self.z_list           = z_list
+        self.mip              = mip
+        self.softmin_temp     = softmin_temp 
+        self.blur_sigma       = blur_sigma
+        super().__init__()
+
+    def task_generator(self):
+        tmp_key = list(self.input_field.keys())[0]
+        tmp_layer = self.input_field[tmp_key]
+        chunks = tmp_layer.break_bcube_into_chunks(
+                    bcube=self.bcube,
+                    chunk_xy=self.chunk_xy,
+                    chunk_z=1,
+                    mip=self.mip)
+
+        tasks = [VoteOverZTask(input_field=self.input_field,
+                            output_field=self.output_field,
+                            mip=self.mip,
+                            bcube=chunk,
+                            z_list=self.z_list,
+                            softmin_temp=self.softmin_temp,
+                            blur_sigma=self.blur_sigma) for chunk in chunks]
+
+        corgie_logger.debug("Yielding VoteMultiZTask for bcube: {}, MIP: {}".format(
+                                self.bcube, self.mip))
+        yield tasks
+
+class VoteOverZTask(scheduling.Task):
+    def __init__(self, 
+                 input_field, 
+                 output_field, 
+                 mip,
+                 bcube,
+                 z_list,
+                 softmin_temp,
+                 blur_sigma=1.):
+        """Find median vector for set of locations in a single field
+        
+        Notes: 
+            Does not ignore identity fields.
+            Padding & cropping is not necessary.
+
+        Args:
+            input_field (Layer)
+            output_field (Layer)
+            mip (int)
+            bcube (BoundingCube)
+            z_list ([int])
+        """
+        super().__init__()
+        self.input_field      = input_field
+        self.output_field     = output_field
+        self.mip              = mip
+        self.bcube            = bcube
+        self.z_list           = z_list
+        if softmin_temp is None:
+            softmin_temp = compute_softmin_temp(dist=1,
+                                                weight=0.99, 
+                                                size=len(z_list))
+        self.softmin_temp     = softmin_temp 
+        self.blur_sigma       = blur_sigma
+
+    def execute(self):
+        fields = []
+        for z in self.z_list:
+            bcube = self.bcube.reset_coords(zs=z, ze=z+1, inplace=False)
+            fields.append(self.input_field.read(bcube, mip=self.mip))
+        fields = torch.cat([f for f in fields]).field()
+        voted_field = fields.vote(softmin_temp=self.softmin_temp,
+                                  blur_sigma=self.blur_sigma)
+        self.output_field.write(data_tens=voted_field, 
+                                    bcube=self.bcube, 
+                                    mip=self.mip)

--- a/corgie/cli/vote.py
+++ b/corgie/cli/vote.py
@@ -3,13 +3,14 @@ from math import log
 from corgie.log import logger as corgie_logger
 from corgie import scheduling, argparsers, helpers, stack
 
+
 def compute_softmin_temp(dist, weight, size):
     """Compute softmin temp given binary assumptions
 
     Assumes that voting subsets are either correct or incorrect.
 
     Args:
-        dist (float): distance between the average differences of 
+        dist (float): distance between the average differences of
             a correct and incorrect subset.
         weight (float): desired weight to be assigned for correct/incorrect
             distance.
@@ -18,58 +19,61 @@ def compute_softmin_temp(dist, weight, size):
     Returns:
         float for softmin temperature that will achieve this weight
     """
-    return -dist / (log(1-weight) - log(weight*size))
+    return -dist / (log(1 - weight) - log(weight * size))
+
 
 class VoteOverFieldsJob(scheduling.Job):
-    def __init__(self,
-                 input_fields,
-                 output_field,
-                 chunk_xy,
-                 bcube,
-                 mip,
-                 softmin_temp=None,
-                 blur_sigma=1.):
-        self.input_fields     = input_fields   
-        self.output_field     = output_field
-        self.chunk_xy         = chunk_xy
-        self.bcube            = bcube
-        self.mip              = mip
-        self.softmin_temp     = softmin_temp 
-        self.blur_sigma       = blur_sigma
+    def __init__(
+        self,
+        input_fields,
+        output_field,
+        chunk_xy,
+        bcube,
+        mip,
+        softmin_temp=None,
+        blur_sigma=1.0,
+    ):
+        self.input_fields = input_fields
+        self.output_field = output_field
+        self.chunk_xy = chunk_xy
+        self.bcube = bcube
+        self.mip = mip
+        self.softmin_temp = softmin_temp
+        self.blur_sigma = blur_sigma
         super().__init__()
 
     def task_generator(self):
         tmp_key = list(self.input_fields.keys())[0]
         tmp_layer = self.input_fields[tmp_key]
         chunks = tmp_layer.break_bcube_into_chunks(
-                    bcube=self.bcube,
-                    chunk_xy=self.chunk_xy,
-                    chunk_z=1,
-                    mip=self.mip)
+            bcube=self.bcube, chunk_xy=self.chunk_xy, chunk_z=1, mip=self.mip
+        )
 
-        tasks = [VoteOverFieldsTask(input_fields=self.input_fields,
-                            output_field=self.output_field,
-                            mip=self.mip,
-                            bcube=chunk,
-                            softmin_temp=self.softmin_temp,
-                            blur_sigma=self.blur_sigma) for chunk in chunks]
+        tasks = [
+            VoteOverFieldsTask(
+                input_fields=self.input_fields,
+                output_field=self.output_field,
+                mip=self.mip,
+                bcube=chunk,
+                softmin_temp=self.softmin_temp,
+                blur_sigma=self.blur_sigma,
+            )
+            for chunk in chunks
+        ]
 
         corgie_logger.debug(
             "Yielding VoteTask for bcube: {}, MIP: {}".format(self.bcube, self.mip)
         )
         yield tasks
 
+
 class VoteOverFieldsTask(scheduling.Task):
-    def __init__(self, 
-                 input_fields, 
-                 output_field, 
-                 mip,
-                 bcube,
-                 softmin_temp,
-                 blur_sigma=1.):
-        """Find median vector for single location over set of fields 
-        
-        Notes: 
+    def __init__(
+        self, input_fields, output_field, mip, bcube, softmin_temp, blur_sigma=1.0
+    ):
+        """Find median vector for single location over set of fields
+
+        Notes:
             Does not ignore identity fields.
             Padding & cropping is not necessary.
 
@@ -80,81 +84,92 @@ class VoteOverFieldsTask(scheduling.Task):
             bcube (BoundingCube)
         """
         super().__init__()
-        self.input_fields     = input_fields
-        self.output_field     = output_field
-        self.mip              = mip
-        self.bcube            = bcube
+        self.input_fields = input_fields
+        self.output_field = output_field
+        self.mip = mip
+        self.bcube = bcube
         if softmin_temp is None:
-            softmin_temp = compute_softmin_temp(dist=1,
-                                                weight=0.99, 
-                                                size=len(input_fields))
-        self.softmin_temp     = softmin_temp 
-        self.blur_sigma       = blur_sigma
+            softmin_temp = compute_softmin_temp(
+                dist=1, weight=0.99, size=len(input_fields)
+            )
+        self.softmin_temp = softmin_temp
+        self.blur_sigma = blur_sigma
 
     def execute(self):
         bcube = self.bcube
         mip = self.mip
         fields = [f.read(bcube, mip=mip) for f in self.input_fields.values()]
         fields = torch.cat([f for f in fields]).field()
-        voted_field = fields.vote(softmin_temp=self.softmin_temp,
-                                  blur_sigma=self.blur_sigma)
-        self.output_field.write(data_tens=voted_field, 
-                                    bcube=bcube, 
-                                    mip=self.mip)
+        voted_field = fields.vote(
+            softmin_temp=self.softmin_temp, blur_sigma=self.blur_sigma
+        )
+        self.output_field.write(data_tens=voted_field, bcube=bcube, mip=self.mip)
+
 
 class VoteOverZJob(scheduling.Job):
-    def __init__(self,
-                 input_field,
-                 output_field,
-                 chunk_xy,
-                 bcube,
-                 z_list,
-                 mip,
-                 softmin_temp=None,
-                 blur_sigma=1.):
-        self.input_field      = input_field   
-        self.output_field     = output_field
-        self.chunk_xy         = chunk_xy
-        self.bcube            = bcube
-        self.z_list           = z_list
-        self.mip              = mip
-        self.softmin_temp     = softmin_temp 
-        self.blur_sigma       = blur_sigma
+    def __init__(
+        self,
+        input_field,
+        output_field,
+        chunk_xy,
+        bcube,
+        z_list,
+        mip,
+        softmin_temp=None,
+        blur_sigma=1.0,
+    ):
+        self.input_field = input_field
+        self.output_field = output_field
+        self.chunk_xy = chunk_xy
+        self.bcube = bcube
+        self.z_list = z_list
+        self.mip = mip
+        self.softmin_temp = softmin_temp
+        self.blur_sigma = blur_sigma
         super().__init__()
 
     def task_generator(self):
         tmp_key = list(self.input_field.keys())[0]
         tmp_layer = self.input_field[tmp_key]
         chunks = tmp_layer.break_bcube_into_chunks(
-                    bcube=self.bcube,
-                    chunk_xy=self.chunk_xy,
-                    chunk_z=1,
-                    mip=self.mip)
+            bcube=self.bcube, chunk_xy=self.chunk_xy, chunk_z=1, mip=self.mip
+        )
 
-        tasks = [VoteOverZTask(input_field=self.input_field,
-                            output_field=self.output_field,
-                            mip=self.mip,
-                            bcube=chunk,
-                            z_list=self.z_list,
-                            softmin_temp=self.softmin_temp,
-                            blur_sigma=self.blur_sigma) for chunk in chunks]
+        tasks = [
+            VoteOverZTask(
+                input_field=self.input_field,
+                output_field=self.output_field,
+                mip=self.mip,
+                bcube=chunk,
+                z_list=self.z_list,
+                softmin_temp=self.softmin_temp,
+                blur_sigma=self.blur_sigma,
+            )
+            for chunk in chunks
+        ]
 
-        corgie_logger.debug("Yielding VoteMultiZTask for bcube: {}, MIP: {}".format(
-                                self.bcube, self.mip))
+        corgie_logger.debug(
+            "Yielding VoteMultiZTask for bcube: {}, MIP: {}".format(
+                self.bcube, self.mip
+            )
+        )
         yield tasks
 
+
 class VoteOverZTask(scheduling.Task):
-    def __init__(self, 
-                 input_field, 
-                 output_field, 
-                 mip,
-                 bcube,
-                 z_list,
-                 softmin_temp,
-                 blur_sigma=1.):
+    def __init__(
+        self,
+        input_field,
+        output_field,
+        mip,
+        bcube,
+        z_list,
+        softmin_temp,
+        blur_sigma=1.0,
+    ):
         """Find median vector for set of locations in a single field
-        
-        Notes: 
+
+        Notes:
             Does not ignore identity fields.
             Padding & cropping is not necessary.
 
@@ -163,29 +178,26 @@ class VoteOverZTask(scheduling.Task):
             output_field (Layer)
             mip (int)
             bcube (BoundingCube)
-            z_list ([int])
+            z_list (range, [int])
         """
         super().__init__()
-        self.input_field      = input_field
-        self.output_field     = output_field
-        self.mip              = mip
-        self.bcube            = bcube
-        self.z_list           = z_list
+        self.input_field = input_field
+        self.output_field = output_field
+        self.mip = mip
+        self.bcube = bcube
+        self.z_list = z_list
         if softmin_temp is None:
-            softmin_temp = compute_softmin_temp(dist=1,
-                                                weight=0.99, 
-                                                size=len(z_list))
-        self.softmin_temp     = softmin_temp 
-        self.blur_sigma       = blur_sigma
+            softmin_temp = compute_softmin_temp(dist=1, weight=0.99, size=len(z_list))
+        self.softmin_temp = softmin_temp
+        self.blur_sigma = blur_sigma
 
     def execute(self):
         fields = []
         for z in self.z_list:
-            bcube = self.bcube.reset_coords(zs=z, ze=z+1, inplace=False)
+            bcube = self.bcube.reset_coords(zs=z, ze=z + 1, inplace=False)
             fields.append(self.input_field.read(bcube, mip=self.mip))
         fields = torch.cat([f for f in fields]).field()
-        voted_field = fields.vote(softmin_temp=self.softmin_temp,
-                                  blur_sigma=self.blur_sigma)
-        self.output_field.write(data_tens=voted_field, 
-                                    bcube=self.bcube, 
-                                    mip=self.mip)
+        voted_field = fields.vote(
+            softmin_temp=self.softmin_temp, blur_sigma=self.blur_sigma
+        )
+        self.output_field.write(data_tens=voted_field, bcube=self.bcube, mip=self.mip)

--- a/corgie/cli/vote.py
+++ b/corgie/cli/vote.py
@@ -129,9 +129,7 @@ class VoteOverZJob(scheduling.Job):
         super().__init__()
 
     def task_generator(self):
-        tmp_key = list(self.input_field.keys())[0]
-        tmp_layer = self.input_field[tmp_key]
-        chunks = tmp_layer.break_bcube_into_chunks(
+        chunks = self.output_field.break_bcube_into_chunks(
             bcube=self.bcube, chunk_xy=self.chunk_xy, chunk_z=1, mip=self.mip
         )
 
@@ -149,9 +147,7 @@ class VoteOverZJob(scheduling.Job):
         ]
 
         corgie_logger.debug(
-            "Yielding VoteMultiZTask for bcube: {}, MIP: {}".format(
-                self.bcube, self.mip
-            )
+            "Yielding VoteOverZTask for bcube: {}, MIP: {}".format(self.bcube, self.mip)
         )
         yield tasks
 
@@ -194,7 +190,7 @@ class VoteOverZTask(scheduling.Task):
     def execute(self):
         fields = []
         for z in self.z_list:
-            bcube = self.bcube.reset_coords(zs=z, ze=z + 1, inplace=False)
+            bcube = self.bcube.reset_coords(zs=z, ze=z + 1, in_place=False)
             fields.append(self.input_field.read(bcube, mip=self.mip))
         fields = torch.cat([f for f in fields]).field()
         voted_field = fields.vote(

--- a/corgie/data_backends/cv.py
+++ b/corgie/data_backends/cv.py
@@ -12,18 +12,34 @@ from corgie import exceptions
 from corgie.log import logger as corgie_logger
 
 from corgie.mipless_cloudvolume import MiplessCloudVolume
-from corgie.data_backends.base import DataBackendBase, BaseLayerBackend, \
-        register_backend, str_to_backend
+from corgie.data_backends.base import (
+    DataBackendBase,
+    BaseLayerBackend,
+    register_backend,
+    str_to_backend,
+)
+
 
 @register_backend("cv")
 class CVDataBackend(DataBackendBase):
     def __init__(self, *kargs, **kwargs):
         super().__init__(*kargs, **kwargs)
+
+
 cv_backend = str_to_backend("cv")
 
+
 class CVLayerBase(BaseLayerBackend):
-    def __init__(self, path, backend, reference=None, force_chunk_xy=None,
-            force_chunk_z=None, overwrite=False, **kwargs):
+    def __init__(
+        self,
+        path,
+        backend,
+        reference=None,
+        force_chunk_xy=None,
+        force_chunk_z=None,
+        overwrite=False,
+        **kwargs,
+    ):
         super().__init__(**kwargs)
         self.path = path
         self.backend = backend
@@ -38,34 +54,35 @@ class CVLayerBase(BaseLayerBackend):
                 overwrite = True
 
         if overwrite:
-            info['num_channels'] = self.get_num_channels()
+            info["num_channels"] = self.get_num_channels()
             if self.dtype is None:
                 dtype = self.get_default_data_type()
             else:
                 dtype = self.dtype
-            info['data_type'] = dtype
+            info["data_type"] = dtype
             if not self.supports_voxel_offset():
-                for scale in info['scales']:
-                    scale['voxel_offset'] = [0, 0, 0]
+                for scale in info["scales"]:
+                    scale["voxel_offset"] = [0, 0, 0]
             if not self.supports_chunking():
-                for scale in info['scales']:
-                    scale['chunk_sizes'] = [[1, 1, 1]]
+                for scale in info["scales"]:
+                    scale["chunk_sizes"] = [[1, 1, 1]]
             if force_chunk_z is not None:
-                for scale in info['scales']:
-                    scale['chunk_sizes'][0][-1] = force_chunk_z
+                for scale in info["scales"]:
+                    scale["chunk_sizes"][0][-1] = force_chunk_z
             if force_chunk_xy is not None:
-                for scale in info['scales']:
-                    scale['chunk_sizes'][0][0] = force_chunk_xy
-                    scale['chunk_sizes'][0][1] = force_chunk_xy
+                for scale in info["scales"]:
+                    scale["chunk_sizes"][0][0] = force_chunk_xy
+                    scale["chunk_sizes"][0][1] = force_chunk_xy
 
-        self.cv = MiplessCloudVolume(path,
-                info=info, overwrite=overwrite,
-                **kwargs)
+        self.cv = MiplessCloudVolume(path, info=info, overwrite=overwrite, **kwargs)
 
-        self.dtype = info['data_type']
+        self.dtype = info["data_type"]
 
     def __str__(self):
         return "CV {}".format(self.path)
+
+    def __repr__(self):
+        return self.__str__()
 
     def get_sublayer(self, name, layer_type=None, path=None, **kwargs):
         if path is None:
@@ -74,9 +91,9 @@ class CVLayerBase(BaseLayerBackend):
         if layer_type is None:
             layer_type = self.get_layer_type()
 
-
-        return self.backend.create_layer(path=path, reference=self,
-                layer_type=layer_type, **kwargs)
+        return self.backend.create_layer(
+            path=path, reference=self, layer_type=layer_type, **kwargs
+        )
 
     def read_backend(self, bcube, mip, transpose=True, timestamp=None, **kwargs):
         x_range = bcube.x_range(mip)
@@ -85,7 +102,7 @@ class CVLayerBase(BaseLayerBackend):
 
         this_cv = self.cv[mip]
         x_off, y_off, z_off = this_cv.voxel_offset
-        '''if x_range[0] < x_off:
+        """if x_range[0] < x_off:
             corgie_logger.debug(f"READ from {str(self)}: \n"
                     f"   reducing xs from {x_range[0]} to {x_off} MIP: {mip}")
             x_range[0] = x_off
@@ -96,10 +113,13 @@ class CVLayerBase(BaseLayerBackend):
         if z_range[0] < z_off:
             corgie_logger.debug(f"READ from {str(self)}: \n"
                     f"   reducing zs from {z_range[0]} to {z_off} MIP: {mip}")
-            z_range[0] = z_off'''
+            z_range[0] = z_off"""
 
-        corgie_logger.debug("READ from {}: \n   x: {}, y: {}, z: {}, MIP: {}".format(
-            str(self), x_range, y_range, z_range, mip))
+        corgie_logger.debug(
+            "READ from {}: \n   x: {}, y: {}, z: {}, MIP: {}".format(
+                str(self), x_range, y_range, z_range, mip
+            )
+        )
         if timestamp is not None:
             data = self.cv[mip].download(
                 bbox=(
@@ -114,11 +134,13 @@ class CVLayerBase(BaseLayerBackend):
                 timestamp=timestamp,
             )
         else:
-            data = self.cv[mip][x_range[0]:x_range[1],
-                        y_range[0]:y_range[1],
-                        z_range[0]:z_range[1]]
+            data = self.cv[mip][
+                x_range[0] : x_range[1],
+                y_range[0] : y_range[1],
+                z_range[0] : z_range[1],
+            ]
         if transpose:
-            data = np.transpose(data, (2,3,0,1))
+            data = np.transpose(data, (2, 3, 0, 1))
         return data
 
     def write_backend(self, data, bcube, mip):
@@ -126,15 +148,17 @@ class CVLayerBase(BaseLayerBackend):
         y_range = bcube.y_range(mip)
         z_range = bcube.z_range()
 
-        data = np.transpose(data, (2,3,0,1))
-        corgie_logger.debug("Write to {}: \n x: {}, y: {}, z: {}, MIP: {}".format(
-            str(self), x_range, y_range, z_range, mip))
+        data = np.transpose(data, (2, 3, 0, 1))
+        corgie_logger.debug(
+            "Write to {}: \n x: {}, y: {}, z: {}, MIP: {}".format(
+                str(self), x_range, y_range, z_range, mip
+            )
+        )
         self.cv[mip].autocrop = True
-        self.cv[mip][x_range[0]:x_range[1],
-                     y_range[0]:y_range[1],
-                     z_range[0]:z_range[1]] = data
+        self.cv[mip][
+            x_range[0] : x_range[1], y_range[0] : y_range[1], z_range[0] : z_range[1]
+        ] = data
         self.cv[mip].autocrop = False
-
 
     def get_info(self):
         return self.cv.get_info()
@@ -147,24 +171,38 @@ class CVLayerBase(BaseLayerBackend):
 
         # Expand bbox to be difizible by chunk_size
 
-        bbox = Bbox((bcube.x_range(mip)[0], bcube.y_range(mip)[0], bcube.z_range()[0]),
-                    (bcube.x_range(mip)[1], bcube.y_range(mip)[1], bcube.z_range()[1]))
+        bbox = Bbox(
+            (bcube.x_range(mip)[0], bcube.y_range(mip)[0], bcube.z_range()[0]),
+            (bcube.x_range(mip)[1], bcube.y_range(mip)[1], bcube.z_range()[1]),
+        )
 
-        aligned_bbox = bbox.expand_to_chunk_size(self.cv[mip].chunk_size,
-                                                 self.cv[mip].voxel_offset)
+        aligned_bbox = bbox.expand_to_chunk_size(
+            self.cv[mip].chunk_size, self.cv[mip].voxel_offset
+        )
 
         aligned_bcube = copy.deepcopy(bcube)
-        aligned_bcube.reset_coords(aligned_bbox.minpt[0], aligned_bbox.maxpt[0],
-                                   aligned_bbox.minpt[1], aligned_bbox.maxpt[1],
-                                   aligned_bbox.minpt[2], aligned_bbox.maxpt[2],
-                                   mip=mip)
+        aligned_bcube.reset_coords(
+            aligned_bbox.minpt[0],
+            aligned_bbox.maxpt[0],
+            aligned_bbox.minpt[1],
+            aligned_bbox.maxpt[1],
+            aligned_bbox.minpt[2],
+            aligned_bbox.maxpt[2],
+            mip=mip,
+        )
 
         if chunk_xy % cv_chunk[0] != 0:
-            raise exceptions.ChunkingError(self, f"Processing chunk_xy {chunk_xy} is not"
-                    f"divisible by MIP{mip} CV chunk {cv_chunk[0]}")
+            raise exceptions.ChunkingError(
+                self,
+                f"Processing chunk_xy {chunk_xy} is not"
+                f"divisible by MIP{mip} CV chunk {cv_chunk[0]}",
+            )
         if chunk_z % cv_chunk[2] != 0:
-            raise exceptions.ChunkingError(self, f"Processing chunk_z {chunk_z} is not"
-                    f"divisible by MIP{mip} CV chunk {cv_chunk[2]}")
+            raise exceptions.ChunkingError(
+                self,
+                f"Processing chunk_z {chunk_z} is not"
+                f"divisible by MIP{mip} CV chunk {cv_chunk[2]}",
+            )
 
         if chunk_xy > aligned_bcube.x_size(mip):
             x_adj = chunk_xy - aligned_bcube.x_size(mip)
@@ -202,14 +240,17 @@ class CVLayerBase(BaseLayerBackend):
             aligned_bcube.reset_coords(ze=ze + z_adj)
         return aligned_bcube
 
-    def break_bcube_into_chunks(self, bcube, chunk_xy, chunk_z, mip,
-            readonly=False, **kwargs):
+    def break_bcube_into_chunks(
+        self, bcube, chunk_xy, chunk_z, mip, readonly=False, **kwargs
+    ):
         if not readonly:
             bcube = self.get_chunk_aligned_bcube(bcube, mip, chunk_xy, chunk_z)
 
-        chunks = super().break_bcube_into_chunks(bcube, chunk_xy, chunk_z,
-                mip, **kwargs)
+        chunks = super().break_bcube_into_chunks(
+            bcube, chunk_xy, chunk_z, mip, **kwargs
+        )
         return chunks
+
 
 @cv_backend.register_layer_type_backend("img")
 class CVImgLayer(CVLayerBase, layers.ImgLayer):
@@ -220,29 +261,33 @@ class CVImgLayer(CVLayerBase, layers.ImgLayer):
 @cv_backend.register_layer_type_backend("segmentation")
 class CVSegmentationLayer(CVLayerBase, layers.SegmentationLayer):
     def __init__(self, *kargs, **kwargs):
-        if 'graphene:' in kwargs['path']:
-            kwargs['readonly'] = True
+        if "graphene:" in kwargs["path"]:
+            kwargs["readonly"] = True
         super().__init__(*kargs, **kwargs)
 
 
 @cv_backend.register_layer_type_backend("field")
 class CVFieldLayer(CVLayerBase, layers.FieldLayer):
-    supported_backend_dtypes = ['float32', 'int16']
-    def __init__(self, backend_dtype='float32', **kwargs):
+    supported_backend_dtypes = ["float32", "int16"]
+
+    def __init__(self, backend_dtype="float32", **kwargs):
         super().__init__(**kwargs)
         if backend_dtype not in self.supported_backend_dtypes:
-            raise exceptions.ArgumentError("Field layer 'backend_dtype'",
-                    "\n{} is not a supported field backend data type. \n"
-                    "Supported backend data types: {}".format(backend_dtype,
-                        self.supported_backend_dtypes)
-                    )
+            raise exceptions.ArgumentError(
+                "Field layer 'backend_dtype'",
+                "\n{} is not a supported field backend data type. \n"
+                "Supported backend data types: {}".format(
+                    backend_dtype, self.supported_backend_dtypes
+                ),
+            )
         self.backend_dtype = backend_dtype
 
     def read_backend(self, bcube, mip, transpose=True, timestamp=None, **kwargs):
         data = super().read_backend(bcube, mip, transpose, timestamp, **kwargs)
-        if self.backend_dtype == 'int16':
+        if self.backend_dtype == "int16":
             data = np.float32(data) / 4
         return data
+
 
 @cv_backend.register_layer_type_backend("mask")
 class CVMaskLayer(CVLayerBase, layers.MaskLayer):
@@ -254,6 +299,7 @@ class CVMaskLayer(CVLayerBase, layers.MaskLayer):
 class CVSectionValueLayer(CVLayerBase, layers.SectionValueLayer):
     def __init__(self, *kargs, **kwargs):
         super().__init__(*kargs, **kwargs)
+
 
 @cv_backend.register_layer_type_backend("fixed_field")
 class CVFixedFieldLayer(CVFieldLayer, layers.FixedFieldLayer):

--- a/corgie/helpers.py
+++ b/corgie/helpers.py
@@ -2,6 +2,7 @@ from dataclasses import astuple, dataclass
 
 import numpy as np
 import torch
+from copy import deepcopy
 
 
 class Binarizer:
@@ -67,11 +68,17 @@ class Translation:
     def round(self, ndigits=None):
         return Translation(round(self.x, ndigits), round(self.y, ndigits))
 
+    def copy(self):
+        return deepcopy(self)
+
     def round_to_mip(self, src_mip, tgt_mip):
-        if tgt_mip <= src_mip:
+        if tgt_mip is None:
+            return self.copy()
+        elif tgt_mip <= src_mip:
             return Translation(self.x, self.y)  # Return copy
-        snap_factor = 2 ** (tgt_mip - src_mip)
-        return (self // snap_factor) * snap_factor
+        else:
+            snap_factor = 2 ** (tgt_mip - src_mip)
+            return (self // snap_factor) * snap_factor
 
 
 def percentile_trans_adjuster(field, h=25, l=75, unaligned_img=None):

--- a/tests/test_block.py
+++ b/tests/test_block.py
@@ -1,0 +1,111 @@
+import pytest
+from corgie.boundingcube import BoundingCube
+from corgie.stack import Stack
+from corgie.layers.base import BaseLayerType
+from corgie.block import Block, partition, get_blocks
+
+
+@pytest.mark.parametrize(
+    "xrange, sz, overlap, skip, result",
+    [
+        (range(4), 2, 0, [], [range(0, 2), range(2, 4)]),
+        (range(4), 2, 1, [], [range(0, 3), range(2, 4)]),
+        (range(4), 2, 0, [2], [range(0, 3), range(3, 4)]),
+        (range(4), 2, 0, [2, 3], [range(0, 4)]),
+        (range(4), 2, 0, [2, 3, 4], [range(0, 4)]),
+        (range(4), 2, 0, [0, 2, 3, 4], [range(0, 4)]),
+        (range(0), 2, 0, [2], []),
+        (range(1), 2, 0, [2], [range(1)]),
+    ],
+)
+def test_partition(xrange, sz, overlap, skip, result):
+    assert partition(xrange, sz, overlap, skip) == result
+
+
+def test_block_get_bcube():
+    bcube = BoundingCube(0, 1, 0, 1, 0, 1, mip=0)
+    start, stop = 10, 11
+    block = Block(
+        start=start, stop=stop, src_stack=Stack(), dst_stack=Stack(), previous=None
+    )
+    adj_bcube = bcube.reset_coords(zs=start, ze=stop, in_place=False)
+    assert adj_bcube == block.get_bcube(bcube)
+    assert bcube.z != (start, stop)
+
+
+def example_blocks():
+    src = Stack("src")
+    even = Stack("even")
+    odd = Stack("odd")
+    blocks = get_blocks(
+        start=0,
+        stop=10,
+        block_size=2,
+        block_overlap=0,
+        skip_list=[],
+        src_stack=src,
+        even_stack=even,
+        odd_stack=odd,
+    )
+    return blocks
+
+
+def test_block_get_previous():
+    blocks = example_blocks()
+    assert blocks[0].previous is None
+    for i in range(1, len(blocks)):
+        assert blocks[i].previous == blocks[i - 1]
+
+
+@pytest.mark.parametrize(
+    "dist, src_id, neighbor_ids",
+    [
+        (2, 0, []),
+        (2, 1, [0]),
+        (3, 1, [0]),
+        (2, 2, [1]),
+        (3, 2, [0, 1]),
+        (8, 4, [0, 1, 2, 3]),
+    ],
+)
+def test_block_get_neighbors(dist, src_id, neighbor_ids):
+    blocks = example_blocks()
+    src = blocks[src_id]
+    neighbors = src.get_neighbors(dist)
+    assert [blocks[i] for i in neighbor_ids] == neighbors
+
+
+@pytest.mark.parametrize(
+    "block_overlap, i, stitch_size, start, stop",
+    [
+        (0, 0, 3, None, None),
+        (0, 1, 3, 4, 7),
+        (0, 1, 1, 4, 5),
+        (1, 1, 1, 5, 6),
+    ],
+)
+def test_block_overlap(block_overlap, i, stitch_size, start, stop):
+    src = Stack("src")
+    even = Stack("even")
+    odd = Stack("odd")
+    field = BaseLayerType(name="field")
+    even.add_layer(field)
+    odd.add_layer(field)
+    blocks = get_blocks(
+        start=0,
+        stop=8,
+        block_size=4,
+        block_overlap=block_overlap,
+        skip_list=[],
+        src_stack=src,
+        even_stack=even,
+        odd_stack=odd,
+    )
+    stitch_block = blocks[i].overlap(stitch_size, "field")
+    if i == 0:
+        assert stitch_block is None
+    else:
+        assert stitch_block.src_stack["field"] == field
+        assert stitch_block.dst_stack == blocks[i].previous.dst_stack
+        assert stitch_block.start == start
+        assert stitch_block.stop == stop

--- a/tests/test_block.py
+++ b/tests/test_block.py
@@ -88,9 +88,6 @@ def test_block_overlap(block_overlap, i, stitch_size, start, stop):
     src = Stack("src")
     even = Stack("even")
     odd = Stack("odd")
-    field = BaseLayerType(name="field")
-    even.add_layer(field)
-    odd.add_layer(field)
     blocks = get_blocks(
         start=0,
         stop=8,
@@ -101,11 +98,10 @@ def test_block_overlap(block_overlap, i, stitch_size, start, stop):
         even_stack=even,
         odd_stack=odd,
     )
-    stitch_block = blocks[i].overlap(stitch_size, "field")
+    stitch_block = blocks[i].overlap(stitch_size)
     if i == 0:
         assert stitch_block is None
     else:
-        assert stitch_block.src_stack["field"] == field
         assert stitch_block.dst_stack == blocks[i].previous.dst_stack
         assert stitch_block.start == start
         assert stitch_block.stop == stop


### PR DESCRIPTION
This updates the `align` method with basic block-stitching. It's only been empirically tested on a limited number of samples.

The current procedure looks like this:

1. Partition range into non-overlapping blocks. For example, blockA will align from 0-10 (10 will not be aligned), and blockB will align from 10-20. If voting is being used during block alignment, then both of these blocks will have starter sections the precede the block. The size of each block is governed by `block_size`, and error correction be specified with `vote_dist`. If `vote_dist == 1` then seethrough will be used, otherwise voting.
2. Compute block-stitching field which aligns the aligned sections of blockB to the aligned sections of blockA. The number of sections to be aligned in this stage are governed by `stitch_size`. If `stitch_size == 1`, then the blocks will be aligned with seethrough, otherwise voting.
3. Broadcast block-stitching fields across the sections which are influenced by the block interface to create their final field. The influence is linearly decayed down to zero if the block-stitching field is `decay_dist` number of sections away. Decaying and composing are handled by [`DistanceFieldSet`](https://github.com/seung-lab/corgie/blob/tmacrina-block-stitch/corgie/stack.py#L273).
4. Render all sections by their final field.

Things that remain to be done:

1. Include drift correction.
2. Use a skip section list when partitioning the range.
3. Copy the fields of the first block into the final field layer of all the other blocks.