### PR TITLE
(fix): Properly handle default device

### DIFF
--- a/corgie/data_backends/base.py
+++ b/corgie/data_backends/base.py
@@ -32,13 +32,12 @@ class DataBackendBase:
 
     def __init__(self, *kargs, device=None, **kwargs):
         self.layer_constr_dict = {n: None for n in get_layer_types()}
-        if device is not None:
-            self.device = device
-        else:
-            self.device = self.default_device
+        self.device = device
         super().__init__(*kargs, **kwargs)
 
     def create_layer(self, path, layer_type=None, reference=None, layer_args={}, **kwargs):
+        if self.device is None:
+            self.device = self.default_device
         if layer_type not in self.layer_constr_dict:
             raise exceptions.CorgieException("Layer type {} is not \
                     defined".format(layer_type))

--- a/corgie/layers/base.py
+++ b/corgie/layers/base.py
@@ -40,7 +40,7 @@ class BaseLayerType:
         # TODO: if np type is unit32, convert it to int64
         if data_np.dtype == np.uint32:
             data_np = data_np.astype(np.int64)
-        data_tens = torch.as_tensor(data_np, device=kwargs.get('device', None))
+        data_tens = torch.as_tensor(data_np, device=kwargs.get('device', self.device))
         data_tens = helpers.cast_tensor_type(data_tens, dtype)
         return data_tens
 


### PR DESCRIPTION
The default device (`--device`) was unused. This fixes it by updating the DataBackend's device to default if it was None, otherwise. The layer now also uses the default device when creating tensors.