### PR TITLE
Fix & speed-up align-block

### DIFF
--- a/corgie/cli/compute_field.py
+++ b/corgie/cli/compute_field.py
@@ -209,9 +209,9 @@ class ComputeFieldTask(scheduling.Task):
         )
 
         # Compensate if target was moved to one side a lot
-        tgt_drift = helpers.percentile_trans_adjuster(
-            tgt_data_dict["tgt_agg_field"], unaligned_img=tgt_data_dict["tgt_img"]
-        )
+        # tgt_drift = helpers.percentile_trans_adjuster(
+        #     tgt_data_dict["tgt_agg_field"], unaligned_img=tgt_data_dict["tgt_img"]
+        # )
         tgt_drift = helpers.Translation(0, 0)
         corgie_logger.debug(f"Read source")
         src_translation, src_data_dict = self.src_stack.read_data_dict(


### PR DESCRIPTION
* Fix voting to occur at lowest MIP
* Fix image rendering to occur at lowest MIP, followed by downsampling,
  because we are not downsampling the voted block field.
* Create a copy of the dst_stack for use during ComputeFieldTask to
  prevent downloading associated fields that are unused.
* Downsample seethrough mask in current section bcube only, instead
  of downsampling the entire block's bcube each time.