### PR TITLE
Use offsets as priors in VoteOverFields

### DIFF
--- a/corgie/cli/vote.py
+++ b/corgie/cli/vote.py
@@ -99,9 +99,11 @@ class VoteOverFieldsTask(scheduling.Task):
         bcube = self.bcube
         mip = self.mip
         fields = [f.read(bcube, mip=mip) for f in self.input_fields.values()]
-        fields = torch.cat([f for f in fields]).field()
-        voted_field = fields.vote(
-            softmin_temp=self.softmin_temp, blur_sigma=self.blur_sigma
+        fields = torch.cat(fields).field()
+        variances = [torch.ones((1, 1, *fields.shape[-2])) / abs(k) for k in self.input_fields.keys()]
+        variances = torch.cat(variances)
+        voted_field = fields.vote_with_variances(
+            var=variances, softmin_temp=self.softmin_temp, blur_sigma=self.blur_sigma
         )
         self.output_field.write(data_tens=voted_field, bcube=bcube, mip=self.mip)
 

--- a/corgie/cli/vote.py
+++ b/corgie/cli/vote.py
@@ -101,7 +101,7 @@ class VoteOverFieldsTask(scheduling.Task):
         fields = [f.read(bcube, mip=mip) for f in self.input_fields.values()]
         fields = torch.cat(fields).field()
         var_shape = (1, 1, *fields.shape[-2:])
-        variances = [torch.ones(var_shape) / abs(k) for k in self.input_fields.keys()]
+        variances = [-torch.ones(var_shape) + abs(k) for k in self.input_fields.keys()]
         variances = torch.cat(variances)
         voted_field = fields.vote_with_variances(
             var=variances, softmin_temp=self.softmin_temp, blur_sigma=self.blur_sigma

--- a/corgie/cli/vote.py
+++ b/corgie/cli/vote.py
@@ -100,7 +100,8 @@ class VoteOverFieldsTask(scheduling.Task):
         mip = self.mip
         fields = [f.read(bcube, mip=mip) for f in self.input_fields.values()]
         fields = torch.cat(fields).field()
-        variances = [torch.ones((1, 1, *fields.shape[-2])) / abs(k) for k in self.input_fields.keys()]
+        var_shape = (1, 1, *fields.shape[-2:])
+        variances = [torch.ones(var_shape) / abs(k) for k in self.input_fields.keys()]
         variances = torch.cat(variances)
         voted_field = fields.vote_with_variances(
             var=variances, softmin_temp=self.softmin_temp, blur_sigma=self.blur_sigma


### PR DESCRIPTION
Use `1 / offset` of a section as a prior in VoteOverFieldsTask. Requires `vote_with_variances` method within [torchfields](https://github.com/seung-lab/torchfields/pull/6). Currently, does not offer an option to not use priors.