### PR TITLE
Changed 'img' to 'image' everywhere for consistency with 'field'

### DIFF
--- a/corgie/cli/align.py
+++ b/corgie/cli/align.py
@@ -202,7 +202,7 @@ def align(
         reference_stack=src_stack,
         folder=dst_folder,
         name="dst",
-        types=["img", "mask"],
+        types=["image", "mask"],
         readonly=False,
         suffix=restart_suffix,
         force_chunk_xy=force_chunk_xy,
@@ -213,7 +213,7 @@ def align(
         reference_stack=src_stack,
         folder=os.path.join(dst_folder, "even"),
         name="even",
-        types=["img", "mask"],
+        types=["image", "mask"],
         readonly=False,
         suffix=suffix,
         force_chunk_xy=force_chunk_xy,
@@ -224,7 +224,7 @@ def align(
         reference_stack=src_stack,
         folder=os.path.join(dst_folder, "odd"),
         name="odd",
-        types=["img", "mask"],
+        types=["image", "mask"],
         readonly=False,
         suffix=suffix,
         force_chunk_xy=force_chunk_xy,
@@ -533,7 +533,7 @@ def align(
         corgie_logger.debug("Done!")
 
     result_report = (
-        f"Aligned layers {[str(l) for l in src_stack.get_layers_of_type('img')]}. "
-        f"Results in {[str(l) for l in dst_stack.get_layers_of_type('img')]}"
+        f"Aligned layers {[str(l) for l in src_stack.get_layers_of_type('image')]}. "
+        f"Results in {[str(l) for l in dst_stack.get_layers_of_type('image')]}"
     )
     corgie_logger.info(result_report)

--- a/corgie/cli/align_block.py
+++ b/corgie/cli/align_block.py
@@ -105,7 +105,7 @@ class AlignBlockJob(scheduling.Job):
                 overwrite=True,
             )
             pixel_offset_layer = tgt_stack.create_unattached_sublayer(
-                f"pixel_offset{self.suffix}", layer_type="img", overwrite=True
+                f"pixel_offset{self.suffix}", layer_type="image", overwrite=True
             )
         else:
             seethrough_mask_layer = None
@@ -342,7 +342,7 @@ class AlignBlockJob(scheduling.Job):
                 if min(self.cf_method.processor_mip) != max(
                     self.cf_method.processor_mip
                 ):
-                    dst_layer = tgt_stack.get_layers_of_type("img")[0]
+                    dst_layer = tgt_stack.get_layers_of_type("image")[0]
                     downsample_job = DownsampleJob(
                         src_layer=dst_layer,
                         chunk_xy=self.cf_method.chunk_xy,
@@ -467,7 +467,7 @@ def align_block(
         reference_stack=src_stack,
         folder=dst_folder,
         name="dst",
-        types=["img", "mask"],
+        types=["image", "mask"],
         readonly=False,
         suffix=suffix,
         force_chunk_xy=force_chunk_xy,
@@ -572,7 +572,7 @@ def align_block(
 
     scheduler.execute_until_completion()
     result_report = (
-        f"Aligned layers {[str(l) for l in src_stack.get_layers_of_type('img')]}. "
-        f"Results in {[str(l) for l in dst_stack.get_layers_of_type('img')]}"
+        f"Aligned layers {[str(l) for l in src_stack.get_layers_of_type('image')]}. "
+        f"Results in {[str(l) for l in dst_stack.get_layers_of_type('image')]}"
     )
     corgie_logger.info(result_report)

--- a/corgie/cli/apply_processor.py
+++ b/corgie/cli/apply_processor.py
@@ -164,7 +164,7 @@ class ApplyProcessorTask(scheduling.Task):
     required=False,
     help="JSON spec relating src stacks, src z to dst z",
 )
-@corgie_option("--reference_key", nargs=1, type=str, default="img")
+@corgie_option("--reference_key", nargs=1, type=str, default="image")
 @corgie_optgroup("Apply Processor Method Specification")
 @corgie_option("--chunk_xy", "-c", nargs=1, type=int, default=1024)
 @corgie_option("--chunk_z", nargs=1, type=int, default=1)
@@ -211,8 +211,8 @@ def apply_processor(
 
     dst_layer = create_layer_from_spec(
         dst_layer_spec,
-        allowed_types=["img", "mask", "section_value"],
-        default_type="img",
+        allowed_types=["image", "mask", "section_value"],
+        default_type="image",
         readonly=False,
         caller_name="dst_layer",
         reference=reference_layer,

--- a/corgie/cli/apply_processor_by_spec.py
+++ b/corgie/cli/apply_processor_by_spec.py
@@ -45,7 +45,7 @@ import json
     required=True,
     help="Specification for the destination layer.",
 )
-@corgie_option("--reference_key", nargs=1, type=str, default="img")
+@corgie_option("--reference_key", nargs=1, type=str, default="image")
 @corgie_optgroup("Apply Processor Method Specification")
 @corgie_option("--chunk_xy", "-c", nargs=1, type=int, default=1024)
 @corgie_option("--chunk_z", nargs=1, type=int, default=1)
@@ -95,8 +95,8 @@ def apply_processor_by_spec(
 
     dst_layer = create_layer_from_spec(
         dst_layer_spec,
-        allowed_types=["img", "mask"],
-        default_type="img",
+        allowed_types=["image", "mask"],
+        default_type="image",
         readonly=False,
         caller_name="dst_layer",
         reference=reference_layer,

--- a/corgie/cli/compare_sections.py
+++ b/corgie/cli/compare_sections.py
@@ -215,7 +215,7 @@ class CompareSectionsTask(scheduling.Task):
     required=True,
     help="Specification for the destination layer. Must be an image or mask type.",
 )
-@corgie_option("--reference_key", nargs=1, type=str, default="img")
+@corgie_option("--reference_key", nargs=1, type=str, default="image")
 @corgie_optgroup("Compute Field Method Specification")
 @corgie_option("--chunk_xy", "-c", nargs=1, type=int, default=1024)
 @corgie_option(
@@ -275,7 +275,7 @@ def compare_sections(
 
     dst_layer = create_layer_from_spec(
         dst_layer_spec,
-        allowed_types=["img", "mask"],
+        allowed_types=["image", "mask"],
         default_type="field",
         readonly=False,
         caller_name="dst_layer",

--- a/corgie/cli/compute_field.py
+++ b/corgie/cli/compute_field.py
@@ -211,7 +211,7 @@ class ComputeFieldTask(scheduling.Task):
 
         # Compensate if target was moved to one side a lot
         # tgt_drift = helpers.percentile_trans_adjuster(
-        #     tgt_data_dict["tgt_agg_field"], unaligned_img=tgt_data_dict["tgt_img"]
+        #     tgt_data_dict["tgt_agg_field"], unaligned_image=tgt_data_dict["tgt_image"]
         # )
         tgt_drift = helpers.Translation(0, 0)
         corgie_logger.debug(f"Read source")
@@ -263,7 +263,7 @@ class ComputeFieldTask(scheduling.Task):
     help="Specification for the destination layer. Must be a field type."
     + " DEFAULT: source reference key path + /field/cf_field + (_{suffix})?",
 )
-@corgie_option("--reference_key", nargs=1, type=str, default="img")
+@corgie_option("--reference_key", nargs=1, type=str, default="image")
 @corgie_optgroup("Compute Field Method Specification")
 @corgie_option("--chunk_xy", "-c", nargs=1, type=int, default=1024)
 @corgie_option("--chunk_z", nargs=1, type=int, default=1)

--- a/corgie/cli/compute_field_by_spec.py
+++ b/corgie/cli/compute_field_by_spec.py
@@ -99,7 +99,7 @@ def compute_field_by_spec(
             for job_spec in spec["job_specs"][spec_z]:
                 src_stack = spec_to_stack(job_spec, "src", src_layers)
                 tgt_stack = spec_to_stack(job_spec, "tgt", tgt_layers)
-                dst_layer = dst_layers[str(job_spec["dst_img"])]
+                dst_layer = dst_layers[str(job_spec["dst_image"])]
                 ps = json.loads(processor_spec[0])
                 ps["ApplyModel"]["params"]["val"] = job_spec["mask_id"]
                 ps["ApplyModel"]["params"]["scale"] = job_spec["scale"]

--- a/corgie/cli/compute_stats.py
+++ b/corgie/cli/compute_stats.py
@@ -314,7 +314,7 @@ def compute_stats_fn(
     bcube = get_bcube_from_coords(start_coord, end_coord, coord_mip)
 
     mask_layers = src_stack.get_layers_of_type(["mask"])
-    non_mask_layers = src_stack.get_layers_of_type(["img", "field"])
+    non_mask_layers = src_stack.get_layers_of_type(["image", "field"])
 
     for l in non_mask_layers:
         mean_layer = src_layer.get_sublayer(

--- a/corgie/cli/copy.py
+++ b/corgie/cli/copy.py
@@ -85,9 +85,9 @@ class CopyTask(scheduling.Task):
         else:
             mask = None
         if self.copy_masks:
-            write_layers = self.dst_stack.get_layers_of_type(["img", "mask"])
+            write_layers = self.dst_stack.get_layers_of_type(["image", "mask"])
         else:
-            write_layers = self.dst_stack.get_layers_of_type("img")
+            write_layers = self.dst_stack.get_layers_of_type("image")
 
         for l in write_layers:
             src = src_data_dict[f"src_{l.name}"]
@@ -172,7 +172,7 @@ def copy(
         reference_stack=src_stack,
         folder=dst_folder,
         name="dst",
-        types=["img", "mask"],
+        types=["image", "mask"],
         readonly=False,
         suffix=suffix,
         force_chunk_xy=force_chunk_xy,

--- a/corgie/cli/fill_nearest.py
+++ b/corgie/cli/fill_nearest.py
@@ -91,8 +91,8 @@ class FillNearestTask(scheduling.Task):
         _, src_data_dict = self.src_stack.read_data_dict(
             bcube=self.bcube, mip=self.mip, add_prefix=False, translation_adjuster=None,
         )
-        layer = self.dst_stack.get_layers_of_type("img")[0]
-        agg_img = src_data_dict[f"{layer.name}"]
+        layer = self.dst_stack.get_layers_of_type("image")[0]
+        agg_image = src_data_dict[f"{layer.name}"]
         agg_mask = self.get_masks(data_dict=src_data_dict, bcube=self.bcube)
         mask_count = agg_mask.sum()
         k = 0
@@ -105,13 +105,13 @@ class FillNearestTask(scheduling.Task):
             _, src_data_dict = self.src_stack.read_data_dict(
                 bcube=bcube, mip=self.mip, add_prefix=False, translation_adjuster=None,
             )
-            img = src_data_dict[f"{layer.name}"]
-            agg_img[agg_mask] = img[agg_mask]
+            image = src_data_dict[f"{layer.name}"]
+            agg_image[agg_mask] = image[agg_mask]
             mask = self.get_masks(data_dict=src_data_dict, bcube=bcube)
             agg_mask = (agg_mask == 1) * (mask == 1)
             mask_count = agg_mask.sum()
             k += 1
-        layer.write(agg_img, bcube=self.bcube, mip=self.mip)
+        layer.write(agg_image, bcube=self.bcube, mip=self.mip)
 
 
 @click.command()
@@ -172,7 +172,7 @@ def fill_nearest(
         reference_stack=src_stack,
         folder=dst_folder,
         name="dst",
-        types=["img", "mask"],
+        types=["image", "mask"],
         readonly=False,
         suffix=suffix,
         overwrite=True,
@@ -195,8 +195,8 @@ def fill_nearest(
 
     scheduler.execute_until_completion()
     result_report = (
-        f"Rendered layers {[str(l) for l in src_stack.get_layers_of_type('img')]}. "
-        f"Results in {[str(l) for l in dst_stack.get_layers_of_type('img')]}"
+        f"Rendered layers {[str(l) for l in src_stack.get_layers_of_type('image')]}. "
+        f"Results in {[str(l) for l in dst_stack.get_layers_of_type('image')]}"
     )
     corgie_logger.info(result_report)
 

--- a/corgie/cli/merge_copy.py
+++ b/corgie/cli/merge_copy.py
@@ -82,8 +82,8 @@ class MergeCopyTask(scheduling.Task):
             src_trans, src_data_dict = self.src_stack.read_data_dict(
                 src_bcube, mip=self.mip, translation_adjuster=None, stack_name="src"
             )
-            img_name = self.src_stack.get_layers_of_type("img")[0].name
-            src_image = src_data_dict[f"src_{img_name}"]
+            image_name = self.src_stack.get_layers_of_type("image")[0].name
+            src_image = src_data_dict[f"src_{image_name}"]
             mask_name = self.src_stack.get_layers_of_type("mask")[0].name
             mask = src_data_dict[f"src_{mask_name}"]
             # mask_layers = src_stack.get_layers_of_type(["mask"])
@@ -94,7 +94,7 @@ class MergeCopyTask(scheduling.Task):
             else:
                 dst_image[mask] = src_image[mask]
 
-        dst_layer = self.dst_stack.get_layers_of_type("img")[0]
+        dst_layer = self.dst_stack.get_layers_of_type("image")[0]
         dst_layer.write(dst_image, bcube=self.bcube, mip=self.mip)
 
 
@@ -107,7 +107,7 @@ class MergeCopyTask(scheduling.Task):
     type=str,
     required=True,
     multiple=True,
-    help="Source layer spec. Order img, mask, img, mask, etc. List must have length of multiple two."
+    help="Source layer spec. Order image, mask, image, mask, etc. List must have length of multiple two."
     + LAYER_HELP_STR,
 )
 #
@@ -160,7 +160,7 @@ def merge_copy(
         src_stack = create_stack_from_spec(
             src_layer_spec[2 * k : 2 * k + 2], name="src", readonly=True
         )
-        name = src_stack.get_layers_of_type("img")[0].path
+        name = src_stack.get_layers_of_type("image")[0].path
         src_stacks[name] = src_stack
 
     with open(spec_path, "r") as f:
@@ -180,7 +180,7 @@ def merge_copy(
         reference_stack=list(src_stacks.values())[0],
         folder=dst_folder,
         name="dst",
-        types=["img"],
+        types=["image"],
         readonly=False,
         suffix=suffix,
         force_chunk_xy=None,

--- a/corgie/cli/normalize.py
+++ b/corgie/cli/normalize.py
@@ -184,7 +184,7 @@ def normalize(
         reference_stack=src_stack,
         folder=dst_folder,
         name="dst",
-        types=["img"],
+        types=["image"],
         readonly=False,
         suffix=suffix,
         overwrite=True,
@@ -192,12 +192,12 @@ def normalize(
 
     bcube = get_bcube_from_coords(start_coord, end_coord, coord_mip)
 
-    img_layers = src_stack.get_layers_of_type("img")
+    image_layers = src_stack.get_layers_of_type("image")
     mask_layers = src_stack.get_layers_of_type("mask")
     field_layers = src_stack.get_layers_of_type("field")
     assert len(field_layers) == 0
 
-    for l in img_layers:
+    for l in image_layers:
         mean_layer = l.get_sublayer(
             name=f"mean_{l.name}{suffix}",
             path=os.path.join(dst_folder, f"mean_{l.name}{suffix}"),
@@ -230,7 +230,7 @@ def normalize(
 
         dst_layer = l.get_sublayer(
             name=f"{l.name}{suffix}",
-            path=os.path.join(dst_folder, "img", f"{l.name}{suffix}"),
+            path=os.path.join(dst_folder, "image", f"{l.name}{suffix}"),
             layer_type=l.get_layer_type(),
             dtype="float32",
             overwrite=True,

--- a/corgie/cli/normalize_by_spec.py
+++ b/corgie/cli/normalize_by_spec.py
@@ -95,12 +95,12 @@ def normalize_by_spec(
 
     bcube = get_bcube_from_coords(start_coord, end_coord, coord_mip)
 
-    img_layers = src_stack.get_layers_of_type("img")
+    image_layers = src_stack.get_layers_of_type("image")
     mask_layers = src_stack.get_layers_of_type("mask")
     field_layers = src_stack.get_layers_of_type("field")
     assert len(field_layers) == 0
 
-    for l in img_layers:
+    for l in image_layers:
         mean_layer = l.get_sublayer(
             name=f"mean{suffix}",
             path=os.path.join(dst_folder, f"mean{suffix}"),
@@ -137,7 +137,7 @@ def normalize_by_spec(
 
         dst_layer = l.get_sublayer(
             name=f"{l.name}{suffix}",
-            path=os.path.join(dst_folder, "img", f"{l.name}{suffix}"),
+            path=os.path.join(dst_folder, "image", f"{l.name}{suffix}"),
             layer_type=l.get_layer_type(),
             dtype="float32",
             overwrite=True,

--- a/corgie/cli/old_compute_field.py
+++ b/corgie/cli/old_compute_field.py
@@ -205,7 +205,7 @@ class ComputeFieldTask(scheduling.Task):
     help="Specification for the destination layer. Must be a field type."
     + " DEFAULT: source reference key path + /field/cf_field + (_{suffix})?",
 )
-@corgie_option("--reference_key", nargs=1, type=str, default="img")
+@corgie_option("--reference_key", nargs=1, type=str, default="image")
 @corgie_optgroup("Compute Field Method Specification")
 @corgie_option("--chunk_xy", "-c", nargs=1, type=int, default=1024)
 @corgie_option("--chunk_z", nargs=1, type=int, default=1)

--- a/corgie/cli/render.py
+++ b/corgie/cli/render.py
@@ -153,7 +153,7 @@ class RenderTask(scheduling.Task):
                 coarsen_factor = int(2 ** (6 - self.mip))
                 agg_mask = helpers.coarsen_mask(agg_mask, coarsen_factor)
                 if agg_field is not None:
-                    warped_mask = residuals.res_warp_img(agg_mask.float(), agg_field)
+                    warped_mask = residuals.res_warp_image(agg_mask.float(), agg_field)
                 else:
                     warped_mask = agg_mask
 
@@ -164,27 +164,27 @@ class RenderTask(scheduling.Task):
                 warped_mask = None
 
         if self.render_masks:
-            write_layers = self.dst_stack.get_layers_of_type(["img", "mask"])
+            write_layers = self.dst_stack.get_layers_of_type(["image", "mask"])
         else:
-            write_layers = self.dst_stack.get_layers_of_type("img")
+            write_layers = self.dst_stack.get_layers_of_type("image")
 
         for l in write_layers:
             src = src_data_dict[f"{l.name}"]
 
             if agg_field is not None:
-                warped_src = residuals.res_warp_img(src.float(), agg_field)
+                warped_src = residuals.res_warp_image(src.float(), agg_field)
             else:
                 warped_src = src
 
             cropped_out = helpers.crop(warped_src, self.pad)
 
-            if l.get_layer_type() == "img":
+            if l.get_layer_type() == "image":
                 if self.blackout_masks and warped_mask is not None:
                     cropped_out[warped_mask] = self.blackout_value
 
                 if self.preserve_zeros and agg_field is not None:
                     src_zero_mask = src == 0
-                    warped_zero_mask = residuals.res_warp_img(
+                    warped_zero_mask = residuals.res_warp_image(
                         src_zero_mask.float(), agg_field
                     )
                     warped_zero_mask = (warped_zero_mask > 0.4).byte()
@@ -287,7 +287,7 @@ def render(
         reference_stack=src_stack,
         folder=dst_folder,
         name="dst",
-        types=["img", "mask"],
+        types=["image", "mask"],
         force_chunk_xy=force_chunk_xy,
         force_chunk_z=force_chunk_z,
         suffix=suffix,

--- a/corgie/cli/seethrough_block.py
+++ b/corgie/cli/seethrough_block.py
@@ -172,7 +172,7 @@ def seethrough_block(
         reference_stack=src_stack,
         folder=dst_folder,
         name="dst",
-        types=["img", "mask"],
+        types=["image", "mask"],
         readonly=False,
         suffix=suffix,
         overwrite=True,
@@ -211,7 +211,7 @@ def seethrough_block(
 
     scheduler.execute_until_completion()
     result_report = (
-        f"Rendered layers {[str(l) for l in src_stack.get_layers_of_type('img')]}. "
-        f"Results in {[str(l) for l in dst_stack.get_layers_of_type('img')]}"
+        f"Rendered layers {[str(l) for l in src_stack.get_layers_of_type('image')]}. "
+        f"Results in {[str(l) for l in dst_stack.get_layers_of_type('image')]}"
     )
     corgie_logger.info(result_report)

--- a/corgie/data_backends/cv.py
+++ b/corgie/data_backends/cv.py
@@ -252,8 +252,8 @@ class CVLayerBase(BaseLayerBackend):
         return chunks
 
 
-@cv_backend.register_layer_type_backend("img")
-class CVImgLayer(CVLayerBase, layers.ImgLayer):
+@cv_backend.register_layer_type_backend("image")
+class CVImageLayer(CVLayerBase, layers.ImageLayer):
     def __init__(self, *kargs, **kwargs):
         super().__init__(*kargs, **kwargs)
 

--- a/corgie/helpers.py
+++ b/corgie/helpers.py
@@ -81,14 +81,14 @@ class Translation:
             return (self // snap_factor) * snap_factor
 
 
-def percentile_trans_adjuster(field, h=25, l=75, unaligned_img=None):
+def percentile_trans_adjuster(field, h=25, l=75, unaligned_image=None):
     if field is None:
         result = Translation(0, 0)
     else:
         nonzero_field_mask = (field[:, 0] != 0) & (field[:, 1] != 0)
 
-        if unaligned_img is not None:
-            no_tissue = field.field().from_pixels()(unaligned_img) == 0
+        if unaligned_image is not None:
+            no_tissue = field.field().from_pixels()(unaligned_image) == 0
             nonzero_field_mask[..., no_tissue.squeeze()] = False
 
         nonzero_field = field[..., nonzero_field_mask.squeeze()].squeeze()

--- a/corgie/layers/__init__.py
+++ b/corgie/layers/__init__.py
@@ -2,11 +2,11 @@ from corgie.layers.base import get_layer_types, str_to_layer_type
 
 # when adding a new layer type, include it here
 from corgie.layers.volumetric_layers import FieldLayer, \
-                                            ImgLayer, \
+                                            ImageLayer, \
                                             MaskLayer, \
                                             SectionValueLayer, \
                                             SegmentationLayer, \
                                             FixedFieldLayer
 
 # also update the default layer type if you want to
-DEFAULT_LAYER_TYPE = 'img'
+DEFAULT_LAYER_TYPE = 'image'

--- a/corgie/layers/volumetric_layers.py
+++ b/corgie/layers/volumetric_layers.py
@@ -99,8 +99,8 @@ class VolumetricLayer(BaseLayerType):
             return xy_chunks
 
 
-@register_layer_type("img")
-class ImgLayer(VolumetricLayer):
+@register_layer_type("image")
+class ImageLayer(VolumetricLayer):
     def __init__(self, *args, num_channels=1, **kwargs):
         super().__init__(*args, **kwargs)
         self.num_channels = num_channels

--- a/corgie/residuals.py
+++ b/corgie/residuals.py
@@ -1,18 +1,18 @@
 import torch
 
-def shift_by_int(img, x_shift, y_shift, is_res=False):
+def shift_by_int(image, x_shift, y_shift, is_res=False):
     if is_res:
-        img = img.permute(0, 3, 1, 2)
+        image = image.permute(0, 3, 1, 2)
 
-    x_shifted = torch.zeros_like(img)
+    x_shifted = torch.zeros_like(image)
     if x_shift > 0:
-        x_shifted[..., x_shift:, :]  = img[..., :-x_shift, :]
+        x_shifted[..., x_shift:, :]  = image[..., :-x_shift, :]
     elif x_shift < 0:
-        x_shifted[..., :x_shift, :]  = img[..., -x_shift:, :]
+        x_shifted[..., :x_shift, :]  = image[..., -x_shift:, :]
     else:
-        x_shifted = img.clone()
+        x_shifted = image.clone()
 
-    result = torch.zeros_like(img)
+    result = torch.zeros_like(image)
     if y_shift > 0:
         result[..., y_shift:]  = x_shifted[..., :-y_shift]
     elif y_shift < 0:
@@ -46,37 +46,37 @@ def res_warp_res(res_a, res_b, is_pix_res=True, permute_field=True):
     return result
 
 
-def res_warp_img(img, res_in, is_pix_res=True,
+def res_warp_image(image, res_in, is_pix_res=True,
         padding_mode='zeros', mode="bilinear",
         permute_field=True):
     if permute_field:
         res_in = res_in.permute(0, 2, 3, 1)
 
     if is_pix_res:
-        res = 2 * res_in / (img.shape[-1])
+        res = 2 * res_in / (image.shape[-1])
     else:
         res = res_in
-    if len(img.shape) == 4:
-        result = gridsample_residual(img, res, padding_mode=padding_mode, mode=mode)
-    elif len(img.shape) == 3:
+    if len(image.shape) == 4:
+        result = gridsample_residual(image, res, padding_mode=padding_mode, mode=mode)
+    elif len(image.shape) == 3:
         if len(res.shape) == 3:
-            result = gridsample_residual(img.unsqueeze(0),
+            result = gridsample_residual(image.unsqueeze(0),
                                          res.unsqueeze(0), padding_mode=padding_mode,
                                          mode=mode)[0]
         else:
-            img = img.unsqueeze(1)
-            result = gridsample_residual(img,
+            image = image.unsqueeze(1)
+            result = gridsample_residual(image,
                                          res,
                                          mode=mode,
                                          padding_mode=padding_mode).squeeze(1)
-    elif len(img.shape) == 2:
-        result = gridsample_residual(img.unsqueeze(0).unsqueeze(0),
+    elif len(image.shape) == 2:
+        result = gridsample_residual(image.unsqueeze(0).unsqueeze(0),
                                      res.unsqueeze(0),
                                      padding_mode=padding_mode,
                                      mode=mode)[0, 0]
     else:
         raise Exception("Image warping requires BxCxHxW or CxHxW format." +
-                        "Recieved dimensions: {}".format(len(img.shape)))
+                        "Recieved dimensions: {}".format(len(image.shape)))
 
     return result
 

--- a/corgie/spec.py
+++ b/corgie/spec.py
@@ -7,14 +7,14 @@ def spec_to_stack(spec, prefix, layers):
     """Create Stack by filtering a dict of layers
 
     Args:
-        spec (dict): job_specs including src_img, src_mask, etc.
+        spec (dict): job_specs including src_image, src_mask, etc.
         prefix (str): src/tgt/dst
         layers (dict): int-indexed dict of layers
 
     job_spec will include index of layer to be used for job
     """
     stack = Stack()
-    for suffix in ['img', 'mask', 'field']:
+    for suffix in ['image', 'mask', 'field']:
         spec_key = '{}_{}'.format(prefix, suffix)
         if spec_key in spec.keys():
             layer_id = str(spec[spec_key])
@@ -46,7 +46,7 @@ def spec_to_layer_dict_overwrite(layer_specs, reference_layer, default_type):
     Args:
         layer_specs (dict): layer specs indexed by unique id
         reference_layer (layer)
-        default_type (str): e.g. img, field
+        default_type (str): e.g. image, field
     """
     layers = {}
     for k, s in layer_specs.items():

--- a/corgie/stack.py
+++ b/corgie/stack.py
@@ -201,7 +201,7 @@ class Stack(StackBase):
             x_offset=translation.y, y_offset=translation.x, mip=mip
         )
 
-        for l in self.get_layers_of_type(["mask", "img"]):
+        for l in self.get_layers_of_type(["mask", "image"]):
             global_name = f"{name_prefix}{l.name}"
             data_dict[global_name] = l.read(bcube=final_bcube, mip=mip)
         return translation, data_dict


### PR DESCRIPTION
Changed every instance of 'img' (whether it's inline, layer names, or type names) to 'image'. 'mask' and 'field' are not shortened to 'msk' or 'fld', and there's no reason why 'img' should be either.

NOTE: metroem must be updated with the Aligner.forward() arg names update for this to work.