### PR TITLE
Update Block to provide broadcasting sections

### DIFF
--- a/corgie/block.py
+++ b/corgie/block.py
@@ -33,6 +33,21 @@ class Block:
             dst_stack=self.previous.dst_stack,
         )
 
+    def broadcastable(self):
+        """Get block representing the sections that are not block aligned by previous block
+
+        Returns:
+            new Block
+        """
+        if self.previous is None:
+            return None
+        return Block(
+            start=self.previous.stop,
+            stop=self.stop,
+            src_stack=self.src_stack,
+            dst_stack=self.dst_stack,
+        )
+
     def get_neighbors(self, dist):
         """Get list of previous blocks where stop is within dist of current block's start.
         Order from furthest to nearest block (convention of FieldSet).

--- a/corgie/cli/align.py
+++ b/corgie/cli/align.py
@@ -247,7 +247,7 @@ def align(
         start=bcube.z_range()[0],
         stop=bcube.z_range()[1],
         block_size=block_size,
-        block_overlap=0,
+        block_overlap=1,
         skip_list=skip_list,
         src_stack=src_stack,
         even_stack=even_stack,
@@ -453,7 +453,7 @@ def align(
     if restart_stage <= 3:
         corgie_logger.debug("Stitching blocks...")
         for block, stitch_block in zip(blocks[1:], stitch_blocks):
-            block_bcube = block.get_bcube(bcube)
+            block_bcube = block.broadcastable().get_bcube(bcube)
             block_list = block.get_neighbors(dist=decay_dist)
             corgie_logger.debug(f"src_block: {block}")
             corgie_logger.debug(f"influencing blocks: {block_list}")


### PR DESCRIPTION
This should make sure the block field for a given section comes from the earliest of a block pair.