### PR TITLE
test(block.py): Add new test + fix 0 length block

### DIFF
--- a/corgie/block.py
+++ b/corgie/block.py
@@ -123,7 +123,9 @@ def partition(xrange, sz, overlap=0, skip=[]):
             xs_stop += 1
         while xs_start in skip and xs_start + overlap < xs_stop:
             xs_start += 1
-        subsets.append(range(xs_start, min(xrange.stop, xs_stop + overlap)))
+        xs_stop = min(xrange.stop, xs_stop + overlap)
+        if xs_start < xs_stop:
+            subsets.append(range(xs_start, xs_stop))
         xs_start = xs_next
         xs_next = min(xs_next + sz, xrange.stop)
     return subsets

--- a/tests/test_block.py
+++ b/tests/test_block.py
@@ -13,9 +13,10 @@ from corgie.block import Block, partition, get_blocks
         (range(4), 2, 0, [2], [range(0, 3), range(3, 4)]),
         (range(4), 2, 0, [2, 3], [range(0, 4)]),
         (range(4), 2, 0, [2, 3, 4], [range(0, 4)]),
-        (range(4), 2, 0, [0, 2, 3, 4], [range(0, 4)]),
+        (range(4), 2, 0, [0, 2, 3, 4], [range(1, 4)]),
         (range(0), 2, 0, [2], []),
         (range(1), 2, 0, [2], [range(1)]),
+        (range(12), 4, 1, [4, 5], [range(0, 7), range(6, 9), range(8, 12)])
     ],
 )
 def test_partition(xrange, sz, overlap, skip, result):


### PR DESCRIPTION
* Avoid 0-length blocks at end of xrange
* Add new test that was incorrectly handled by previous `partition` function
* Fix test to reflect that we now allow to skip `xrange.start`