### PR TITLE
perf: speed up BroadcastTask with z-chunking & caching

### DIFF
--- a/corgie/cli/align.py
+++ b/corgie/cli/align.py
@@ -106,6 +106,7 @@ from corgie.cli.broadcast import BroadcastJob
     default=1,
     help="The number of previous sections for which fields will be estimated, then corrected by voting.",
 )
+@corgie_optgroup("Broadcast Specification")
 @corgie_option(
     "--decay_dist",
     nargs=1,
@@ -120,6 +121,8 @@ from corgie.cli.broadcast import BroadcastJob
     default=0.2,
     help="The increase in the size of downsample factor based on distance used in broadcasting a stitching field.",
 )
+@corgie_option("--broadcast_chunk_z", nargs=1, type=int, default=1)
+@corgie_optgroup("Restart Specification")
 @corgie_option(
     "--restart_stage",
     nargs=1,
@@ -161,6 +164,7 @@ def align(
     seethrough_spec_mip,
     decay_dist,
     blur_rate,
+    broadcast_chunk_z,
     restart_stage,
     restart_suffix,
 ):
@@ -305,8 +309,8 @@ def align(
     else:
         seethrough_method = None
 
-    #restart_stage = 4
-    #import pdb; pdb.set_trace()
+    # restart_stage = 4
+    # import pdb; pdb.set_trace()
     if restart_stage == 0:
         corgie_logger.debug("Aligning blocks...")
         for block in blocks:
@@ -404,9 +408,9 @@ def align(
                 field_to_downsample = stitch_corrected_field
             # Hack for fafb
             field_info = field_to_downsample.get_info()
-            for scale in field_info['scales']:
-                scale['chunk_sizes'][-1][-1] = 1
-                scale['encoding'] = 'raw'
+            for scale in field_info["scales"]:
+                scale["chunk_sizes"][-1][-1] = 1
+                scale["encoding"] = "raw"
             field_to_downsample.cv.store_info(field_info)
             field_to_downsample.cv.fetch_info()
             downsample_field_job = DownsampleJob(
@@ -465,6 +469,7 @@ def align(
                 stitching_fields=stitching_fields,
                 output_field=composed_field,
                 chunk_xy=chunk_xy,
+                chunk_z=broadcast_chunk_z,
                 bcube=block_bcube,
                 pad=pad,
                 z_list=z_list,

--- a/corgie/cli/broadcast.py
+++ b/corgie/cli/broadcast.py
@@ -167,7 +167,9 @@ class BroadcastTask(scheduling.Task):
             input_fields = fmul * input_fields + input_fields[:frem]
             input_fields = input_fields[::-1]
         input_fields += [self.block_field]
+        field_cache_vals = {}
         for field in input_fields:
+            field_cache_vals[field] = field.get_param(key="cache")
             field.cv.set_param(key="cache", value=True)
         for z in range(*self.bcube.z_range()):
             bcube = self.bcube.reset_coords(zs=z, ze=z + 1, in_place=False)
@@ -195,4 +197,4 @@ class BroadcastTask(scheduling.Task):
                 layer.flush(mip)
 
         for field in input_fields:
-            field.cv.set_param(key="cache", value=False)
+            field.cv.set_param(key="cache", value=field_cache_vals[field])

--- a/corgie/cli/broadcast.py
+++ b/corgie/cli/broadcast.py
@@ -167,6 +167,8 @@ class BroadcastTask(scheduling.Task):
             input_fields = fmul * input_fields + input_fields[:frem]
             input_fields = input_fields[::-1]
         input_fields += [self.block_field]
+        for field in input_fields:
+            field.cv.set_param(key="cache", value=True)
         for z in range(*self.bcube.z_range()):
             bcube = self.bcube.reset_coords(zs=z, ze=z + 1, in_place=False)
             z_list = self.z_list + [bcube.z_range()[0]]
@@ -191,3 +193,6 @@ class BroadcastTask(scheduling.Task):
         for layer in input_fields:
             for mip in mips:
                 layer.flush(mip)
+
+        for field in input_fields:
+            field.cv.set_param(key="cache", value=False)

--- a/corgie/cli/broadcast.py
+++ b/corgie/cli/broadcast.py
@@ -18,6 +18,7 @@ class BroadcastJob(scheduling.Job):
         mip,
         decay_dist,
         blur_rate,
+        chunk_z,
     ):
         """
         Args:
@@ -34,6 +35,7 @@ class BroadcastJob(scheduling.Job):
         self.block_field = block_field
         self.stitching_fields = stitching_fields
         self.output_field = output_field
+        self.chunk_z = chunk_z
         self.chunk_xy = chunk_xy
         self.bcube = bcube
         self.pad = pad
@@ -45,7 +47,7 @@ class BroadcastJob(scheduling.Job):
 
     def task_generator(self):
         chunks = self.output_field.break_bcube_into_chunks(
-            bcube=self.bcube, chunk_xy=self.chunk_xy, chunk_z=1, mip=self.mip
+            bcube=self.bcube, chunk_xy=self.chunk_xy, chunk_z=self.chunk_z, mip=self.mip
         )
 
         tasks = []

--- a/corgie/mipless_cloudvolume.py
+++ b/corgie/mipless_cloudvolume.py
@@ -109,6 +109,7 @@ class MiplessCloudVolume:
         self.cv_params.setdefault("fill_missing", True)
         self.cv_params.setdefault("delete_black_uploads", True)
         self.cv_params.setdefault("agglomerate", True)
+        self.cv_params.setdefault("cache", False)
 
         # for k, v in six.iteritems(kwargs):
         #     self.cv_params[k] = v
@@ -127,6 +128,9 @@ class MiplessCloudVolume:
     # def exists(self):
     #       s = Storage(self.path)
     #       return s.exists('info')
+
+    def set_param(self, key: str, value: Any):
+        self.cv_params[key] = value
 
     def fetch_info(self):
         print("Fetching info")

--- a/corgie/mipless_cloudvolume.py
+++ b/corgie/mipless_cloudvolume.py
@@ -1,4 +1,5 @@
 import json
+from typing import Any
 import six
 import copy
 import cachetools
@@ -8,82 +9,106 @@ from cloudvolume import CloudVolume, Storage
 
 from corgie.log import logger as corgie_logger
 
+
 def jsonize_key(*kargs, **kwargs):
-    result = ''
+    result = ""
     for k in kargs[1:]:
         result += json.dumps(k)
-        result += '_'
+        result += "_"
 
     result += json.dumps(kwargs, sort_keys=True)
     return result
+
 
 def cv_is_cached(*kargs, **kwargs):
     key = jsonize_key(*kargs, **kwargs)
     return key in cv_cache
 
+
 cv_cache = cachetools.LRUCache(maxsize=500)
+
+
 class CachedCloudVolume(CloudVolume):
-    @cachetools.cached(
-        cv_cache,
-        key=jsonize_key
-    )
+    @cachetools.cached(cv_cache, key=jsonize_key)
     def __new__(self, *args, **kwargs):
         return super().__new__(self, *args, **kwargs)
 
+
 def deserialize_miplessCV_old(s, cache={}):
-        if s in cache:
-            return cache[s]
-        else:
-            contents = json.loads(s)
-            mcv = MiplessCloudVolume(contents['path'], mkdir=contents['mkdir'],
-                                                             **contents['kwargs'])
-            cache[s] = mcv
-            return mcv
+    if s in cache:
+        return cache[s]
+    else:
+        contents = json.loads(s)
+        mcv = MiplessCloudVolume(
+            contents["path"], mkdir=contents["mkdir"], **contents["kwargs"]
+        )
+        cache[s] = mcv
+        return mcv
+
 
 def deserialize_miplessCV_old2(s, cache={}):
-        cv_kwargs = {'bounded': False, 'progress': False,
-                     'autocrop': False, 'non_aligned_writes': False,
-                     'cdn_cache': False}
-        if s in cache:
-            return cache[s]
-        else:
-            contents = json.loads(s)
-            mcv = MiplessCloudVolume(contents['path'], mkdir=False,
-                                                             fill_missing=True, **cv_kwargs)
-            cache[s] = mcv
-            return mcv
+    cv_kwargs = {
+        "bounded": False,
+        "progress": False,
+        "autocrop": False,
+        "non_aligned_writes": False,
+        "cdn_cache": False,
+    }
+    if s in cache:
+        return cache[s]
+    else:
+        contents = json.loads(s)
+        mcv = MiplessCloudVolume(
+            contents["path"], mkdir=False, fill_missing=True, **cv_kwargs
+        )
+        cache[s] = mcv
+        return mcv
+
 
 def deserialize_miplessCV(s, cache={}):
-        cv_kwargs = {'bounded': False, 'progress': False,
-                    'autocrop': False, 'non_aligned_writes': False,
-                    'cdn_cache': False}
-        if s in cache:
-            return cache[s]
-        else:
-            mcv = MiplessCloudVolume(s, mkdir=False,
-                                                             fill_missing=True, **cv_kwargs)
-            cache[s] = mcv
-            return mcv
+    cv_kwargs = {
+        "bounded": False,
+        "progress": False,
+        "autocrop": False,
+        "non_aligned_writes": False,
+        "cdn_cache": False,
+    }
+    if s in cache:
+        return cache[s]
+    else:
+        mcv = MiplessCloudVolume(s, mkdir=False, fill_missing=True, **cv_kwargs)
+        cache[s] = mcv
+        return mcv
 
-class MiplessCloudVolume():
+
+class MiplessCloudVolume:
     """Multi-mip access to CloudVolumes using the same path
     """
-    def __init__(self, path, info=None, allow_info_writes=True, obj=CachedCloudVolume,
-            default_chunk=(512, 512, 1), overwrite=False, **kwargs):
+
+    def __init__(
+        self,
+        path,
+        info=None,
+        allow_info_writes=True,
+        obj=CachedCloudVolume,
+        default_chunk=(512, 512, 1),
+        overwrite=False,
+        **kwargs
+    ):
         self.path = path
         self.allow_info_writes = allow_info_writes
         self.cv_params = {}
-        self.cv_params['info'] = info
-        if 'cv_params' in kwargs:
-            self.cv_params.update(kwargs['cv_params'])
-        self.cv_params.setdefault('bounded', False)
-        self.cv_params.setdefault('progress', False)
-        self.cv_params.setdefault('autocrop', False)
-        self.cv_params.setdefault('non_aligned_writes', False)
-        self.cv_params.setdefault('cdn_cache', False)
-        self.cv_params.setdefault('fill_missing', True)
-        self.cv_params.setdefault('delete_black_uploads', True)
-        self.cv_params.setdefault('agglomerate', True)
+        self.cv_params["info"] = info
+        if "cv_params" in kwargs:
+            self.cv_params.update(kwargs["cv_params"])
+        self.cv_params.setdefault("bounded", False)
+        self.cv_params.setdefault("progress", False)
+        self.cv_params.setdefault("autocrop", False)
+        self.cv_params.setdefault("non_aligned_writes", False)
+        self.cv_params.setdefault("cdn_cache", False)
+        self.cv_params.setdefault("fill_missing", True)
+        self.cv_params.setdefault("delete_black_uploads", True)
+        self.cv_params.setdefault("agglomerate", True)
 
         # for k, v in six.iteritems(kwargs):
         #     self.cv_params[k] = v
@@ -104,36 +129,40 @@ class MiplessCloudVolume():
     #       return s.exists('info')
 
     def fetch_info(self):
-        print ("Fetching info")
+        print("Fetching info")
         tmp_cv = self.obj(self.path, **self.cv_params)
         self.info = tmp_cv.info
 
     def serialize(self):
-            contents = {
-                   "path" : self.path,
-                   "allow_info_writes" : self.allow_info_writes,
-                   "cv_params": self.cv_params,
-            }
-            s = json.dumps(contents)
-            return s
+        contents = {
+            "path": self.path,
+            "allow_info_writes": self.allow_info_writes,
+            "cv_params": self.cv_params,
+        }
+        s = json.dumps(contents)
+        return s
 
     @classmethod
     def deserialize(cls, s, cache={}, **kwargs):
-            if s in cache:
-                return cache[s]
-            else:
-                import pdb; pdb.set_trace()
-                mcv = cls(s,  **kwargs)
-                cache[s] = mcv
-                return mcv
+        if s in cache:
+            return cache[s]
+        else:
+            import pdb
+
+            pdb.set_trace()
+            mcv = cls(s, **kwargs)
+            cache[s] = mcv
+            return mcv
 
     def get_info(self):
         return self.info
 
     def store_info(self, info=None):
         if not self.allow_info_writes:
-            raise Exception("Attempting to store info to {}, but "
-                    "'allow_info_writes' flag is set to False".format(self.path))
+            raise Exception(
+                "Attempting to store info to {}, but "
+                "'allow_info_writes' flag is set to False".format(self.path)
+            )
 
         tmp_cv = self.obj(self.path, **self.cv_params)
         if info is not None:
@@ -144,62 +173,66 @@ class MiplessCloudVolume():
 
     def ensure_info_has_mip(self, mip):
         tmp_cv = self.obj(self.path, **self.cv_params)
-        scale_num = len(tmp_cv.info['scales'])
+        scale_num = len(tmp_cv.info["scales"])
 
         if scale_num < mip + 1:
             while scale_num < mip + 1:
-                tmp_cv.add_scale((2**scale_num, 2**scale_num, 1),
-                        chunk_size=self.default_chunk)
+                tmp_cv.add_scale(
+                    (2 ** scale_num, 2 ** scale_num, 1), chunk_size=self.default_chunk
+                )
                 scale_num += 1
 
             self.store_info(tmp_cv.info)
 
     def extend_info_to_mip(self, mip):
         info = self.get_info()
-        highest_mip = len(info['scales']) - 1
-        highest_mip_info = info['scales'][-1]
+        highest_mip = len(info["scales"]) - 1
+        highest_mip_info = info["scales"][-1]
 
         if highest_mip >= mip:
             return
 
-        while (highest_mip < mip):
+        while highest_mip < mip:
             new_highest_mip_info = copy.deepcopy(highest_mip_info)
-            #size
-            #voxel offset
-            #resolution -> key
-            new_highest_mip_info['size'] = [
-                    highest_mip_info['size'][0] // 2,
-                    highest_mip_info['size'][1] // 2,
-                    highest_mip_info['size'][2]
-                ]
+            # size
+            # voxel offset
+            # resolution -> key
+            new_highest_mip_info["size"] = [
+                highest_mip_info["size"][0] // 2,
+                highest_mip_info["size"][1] // 2,
+                highest_mip_info["size"][2],
+            ]
 
-            new_highest_mip_info['voxel_offset'] = [
-                    highest_mip_info['voxel_offset'][0] // 2,
-                    highest_mip_info['voxel_offset'][1] // 2,
-                    highest_mip_info['voxel_offset'][2]
-                ]
+            new_highest_mip_info["voxel_offset"] = [
+                highest_mip_info["voxel_offset"][0] // 2,
+                highest_mip_info["voxel_offset"][1] // 2,
+                highest_mip_info["voxel_offset"][2],
+            ]
 
-            new_highest_mip_info['resolution'] = [
-                    highest_mip_info['resolution'][0] * 2,
-                    highest_mip_info['resolution'][1] * 2,
-                    highest_mip_info['resolution'][2]
-                ]
+            new_highest_mip_info["resolution"] = [
+                highest_mip_info["resolution"][0] * 2,
+                highest_mip_info["resolution"][1] * 2,
+                highest_mip_info["resolution"][2],
+            ]
 
-            new_highest_mip_info['key'] = '_'.join([str(i) for i in new_highest_mip_info['resolution']])
-            info['scales'].append(new_highest_mip_info)
+            new_highest_mip_info["key"] = "_".join(
+                [str(i) for i in new_highest_mip_info["resolution"]]
+            )
+            info["scales"].append(new_highest_mip_info)
             highest_mip += 1
             highest_mip_info = new_highest_mip_info
 
         self.store_info()
 
     def create(self, mip):
-        corgie_logger.debug('Creating CloudVolume for {0} at MIP{1}'.format(self.path, mip))
+        corgie_logger.debug(
+            "Creating CloudVolume for {0} at MIP{1}".format(self.path, mip)
+        )
         self.extend_info_to_mip(mip)
 
         self.cvs[mip] = self.obj(self.path, mip=mip, **self.cv_params)
 
-
-        #if self.mkdir:
+        # if self.mkdir:
         #  self.cvs[mip].commit_info()
         #  self.cvs[mip].commit_provenance()
 

--- a/corgie/mipless_cloudvolume.py
+++ b/corgie/mipless_cloudvolume.py
@@ -129,6 +129,10 @@ class MiplessCloudVolume:
     #       s = Storage(self.path)
     #       return s.exists('info')
 
+    def get_param(self, key: str):
+        return self.cv_params[key]
+
+
     def set_param(self, key: str, value: Any):
         self.cv_params[key] = value
 

--- a/tests/test_mipless_cloudvolume.py
+++ b/tests/test_mipless_cloudvolume.py
@@ -1,0 +1,32 @@
+import pytest
+from cloudvolume import CloudVolume
+from cloudvolume.lib import Vec
+from corgie.mipless_cloudvolume import MiplessCloudVolume
+
+
+def create_dummy_mipless_cloudvolume():
+    mip = 0
+    volume_size = Vec(128, 64, 30)
+    chunk_size = Vec(64, 64, 1)
+    info = CloudVolume.create_new_info(
+        num_channels=1,
+        layer_type="image",
+        data_type="uint8",
+        encoding="raw",
+        resolution=[1, 1, 1],
+        voxel_offset=[0, 0, 0],
+        chunk_size=chunk_size,
+        volume_size=volume_size,
+    )
+    return MiplessCloudVolume(
+        path="file:///tmp/corgie/test", info=info, overwrite=False
+    )
+
+
+def test_set_param():
+    cv = create_dummy_mipless_cloudvolume()
+    cv.set_param("cache", True)
+    assert cv.cv_params["cache"]
+    cv.set_param("cache", False)
+    assert not cv.cv_params["cache"]
+


### PR DESCRIPTION
BroadcastTasks pull the same set of stitching fields for neighboring sections. This PR allows BroadcastTasks to be chunked in z, and turns on the CloudVolume cache so that stitching fields do not need to be downloaded for each section.