### PR TITLE
feat: write out voting weights

### DIFF
--- a/corgie/cli/__init__.py
+++ b/corgie/cli/__init__.py
@@ -23,6 +23,7 @@ from corgie.cli.downsample_by_spec import downsample_by_spec
 from corgie.cli.compare_sections import compare_sections
 from corgie.cli.seethrough_block import seethrough_block
 from corgie.cli.fill_nearest import fill_nearest
+from corgie.cli.vote import vote
 
 COMMAND_LIST = []
 COMMAND_LIST.append(downsample)
@@ -48,6 +49,7 @@ COMMAND_LIST.append(normalize_by_spec)
 COMMAND_LIST.append(downsample_by_spec)
 COMMAND_LIST.append(seethrough_block)
 COMMAND_LIST.append(fill_nearest)
+COMMAND_LIST.append(vote)
 
 
 def get_command_list():

--- a/corgie/data_backends/cv.py
+++ b/corgie/data_backends/cv.py
@@ -305,3 +305,9 @@ class CVSectionValueLayer(CVLayerBase, layers.SectionValueLayer):
 class CVFixedFieldLayer(CVFieldLayer, layers.FixedFieldLayer):
     def __init__(self, *kargs, **kwargs):
         super().__init__(*kargs, **kwargs)
+
+
+@cv_backend.register_layer_type_backend("float_tensor")
+class CVFloatTensorLayer(CVLayerBase, layers.FloatTensorLayer):
+    def __init__(self, *kargs, **kwargs):
+        super().__init__(*kargs, **kwargs)

--- a/corgie/layers/__init__.py
+++ b/corgie/layers/__init__.py
@@ -1,12 +1,15 @@
 from corgie.layers.base import get_layer_types, str_to_layer_type
 
 # when adding a new layer type, include it here
-from corgie.layers.volumetric_layers import FieldLayer, \
-                                            ImgLayer, \
-                                            MaskLayer, \
-                                            SectionValueLayer, \
-                                            SegmentationLayer, \
-                                            FixedFieldLayer
+from corgie.layers.volumetric_layers import (
+    FieldLayer,
+    ImgLayer,
+    MaskLayer,
+    SectionValueLayer,
+    SegmentationLayer,
+    FixedFieldLayer,
+    FloatTensorLayer,
+)
 
 # also update the default layer type if you want to
-DEFAULT_LAYER_TYPE = 'img'
+DEFAULT_LAYER_TYPE = "img"

--- a/corgie/layers/volumetric_layers.py
+++ b/corgie/layers/volumetric_layers.py
@@ -9,13 +9,16 @@ from corgie.boundingcube import BoundingCube
 from corgie.layers.base import register_layer_type, BaseLayerType
 from corgie import helpers
 
+
 def get_extra_interpolate_parameters():
     # torch.nn.function.interpolate complains if this
     # argument is not provided, but it doesn't exist in older versions
     from packaging import version
+
     if version.parse(torch.__version__) <= version.parse("1.4.0"):
         return {}
     return {"recompute_scale_factor": False}
+
 
 class VolumetricLayer(BaseLayerType):
     def __init__(self, data_mip=None, **kwargs):
@@ -26,22 +29,25 @@ class VolumetricLayer(BaseLayerType):
         indexed_bcube = self.indexing_scheme(bcube, mip, kwargs)
         if self.data_mip is not None:
             if mip <= self.data_mip:
-                result_data_mip = super().read(bcube=indexed_bcube,
-                        mip=self.data_mip, **kwargs)
+                result_data_mip = super().read(
+                    bcube=indexed_bcube, mip=self.data_mip, **kwargs
+                )
                 result = result_data_mip
                 for _ in range(mip, self.data_mip):
                     result = self.get_upsampler()(result)
             elif mip > self.data_mip:
                 # TODO: consider restricting MIP difference to prevent memory blow-up
-                result_data_mip = super().read(bcube=indexed_bcube,
-                        mip=self.data_mip, **kwargs)
+                result_data_mip = super().read(
+                    bcube=indexed_bcube, mip=self.data_mip, **kwargs
+                )
                 result = result_data_mip
                 for _ in range(self.data_mip, mip):
                     result = self.get_downsampler()(result)
             else:
                 # TODO: consider restricting MIP difference to prevent memory blow-up
-                result_data_mip = super().read(bcube=indexed_bcube,
-                        mip=self.data_mip, **kwargs)
+                result_data_mip = super().read(
+                    bcube=indexed_bcube, mip=self.data_mip, **kwargs
+                )
                 result = result_data_mip
                 for _ in range(self.data_mip, mip):
                     result = self.get_downsampler()(result)
@@ -57,9 +63,17 @@ class VolumetricLayer(BaseLayerType):
     def indexing_scheme(self, bcube, mip, kwargs):
         return bcube
 
-    def break_bcube_into_chunks(self, bcube, chunk_xy, chunk_z,
-            mip, flatten=True, chunk_xy_step=None, chunk_z_step=None,
-            **kwargs):
+    def break_bcube_into_chunks(
+        self,
+        bcube,
+        chunk_xy,
+        chunk_z,
+        mip,
+        flatten=True,
+        chunk_xy_step=None,
+        chunk_z_step=None,
+        **kwargs
+    ):
         """Default breaking up of a bcube into smaller bcubes (chunks).
         Returns a list of chunks
         Args:
@@ -85,10 +99,9 @@ class VolumetricLayer(BaseLayerType):
             for xs in range(x_range[0], x_range[1], chunk_xy_step):
                 xy_chunks[-1].append([])
                 for ys in range(y_range[0], y_range[1], chunk_xy_step):
-                    chunk = BoundingCube(xs, xs + chunk_xy,
-                                         ys, ys + chunk_xy,
-                                         zs, zs + chunk_z,
-                                         mip=mip)
+                    chunk = BoundingCube(
+                        xs, xs + chunk_xy, ys, ys + chunk_xy, zs, zs + chunk_z, mip=mip
+                    )
 
                     xy_chunks[-1][-1].append(chunk)
                     flat_chunks.append(chunk)
@@ -107,37 +120,45 @@ class ImgLayer(VolumetricLayer):
 
     def get_downsampler(self):
         def downsampler(data_tens):
-            return torch.nn.functional.interpolate(data_tens.float(),
-                    mode='bilinear',
-                    scale_factor=1/2,
-                    align_corners=False,
-                    **get_extra_interpolate_parameters())
+            return torch.nn.functional.interpolate(
+                data_tens.float(),
+                mode="bilinear",
+                scale_factor=1 / 2,
+                align_corners=False,
+                **get_extra_interpolate_parameters()
+            )
+
         return downsampler
 
     def get_upsampler(self):
         def upsampler(data_tens):
-            return torch.nn.functional.interpolate(data_tens.float(),
-                    mode='bilinear',
-                    scale_factor=2.0,
-                    align_corners=False,
-                    **get_extra_interpolate_parameters())
+            return torch.nn.functional.interpolate(
+                data_tens.float(),
+                mode="bilinear",
+                scale_factor=2.0,
+                align_corners=False,
+                **get_extra_interpolate_parameters()
+            )
+
         return upsampler
 
     def get_num_channels(self, *args, **kwargs):
         return self.num_channels
 
     def get_default_data_type(self):
-        return 'uint8'
+        return "uint8"
 
 
 @register_layer_type("segmentation")
 class SegmentationLayer(VolumetricLayer):
     def __init__(self, *args, num_channels=1, **kwargs):
         if num_channels != 1:
-            raise exceptions.ArgumentError("Segmentation layer 'num_channels'",
-                    "Segmentation layer must have 1 channels. 'num_channels' provided: {}".format(
-                        num_channels
-                        ))
+            raise exceptions.ArgumentError(
+                "Segmentation layer 'num_channels'",
+                "Segmentation layer must have 1 channels. 'num_channels' provided: {}".format(
+                    num_channels
+                ),
+            )
         super().__init__(*args, **kwargs)
 
     def read(self, dtype=None, **kwargs):
@@ -145,22 +166,26 @@ class SegmentationLayer(VolumetricLayer):
 
     def get_downsampler(self):
         def downsampler(data_tens):
-            downs_data = torch.nn.functional.interpolate(data_tens.float(),
-                                mode='nearest',
-                                scale_factor=1/2,
-                                align_corners=False,
-                                **get_extra_interpolate_parameters())
+            downs_data = torch.nn.functional.interpolate(
+                data_tens.float(),
+                mode="nearest",
+                scale_factor=1 / 2,
+                align_corners=False,
+                **get_extra_interpolate_parameters()
+            )
             return downs_data
 
         return downsampler
 
     def get_upsampler(self):
         def upsampler(data_tens):
-            ups_data = torch.nn.functional.interpolate(data_tens.float(),
-                                mode='nearest',
-                                scale_factor=2.0,
-                                align_corners=False,
-                                **get_extra_interpolate_parameters())
+            ups_data = torch.nn.functional.interpolate(
+                data_tens.float(),
+                mode="nearest",
+                scale_factor=2.0,
+                align_corners=False,
+                **get_extra_interpolate_parameters()
+            )
             return ups_data
 
         return upsampler
@@ -169,40 +194,47 @@ class SegmentationLayer(VolumetricLayer):
         return 1
 
     def get_default_data_type(self):
-        return 'uint64'
+        return "uint64"
 
 
 @register_layer_type("field")
 class FieldLayer(VolumetricLayer):
     """Residuals are specified at a relative resolution based on MIP
     """
+
     def __init__(self, *args, num_channels=2, **kwargs):
         if num_channels != 2:
-            raise exceptions.ArgumentError("Field layer 'num_channels'",
-                    "Field layer must have 2 channels. 'num_channels' provided: {}".format(
-                        num_channels
-                        ))
+            raise exceptions.ArgumentError(
+                "Field layer 'num_channels'",
+                "Field layer must have 2 channels. 'num_channels' provided: {}".format(
+                    num_channels
+                ),
+            )
         super().__init__(*args, **kwargs)
 
     def get_downsampler(self):
         def downsampler(data_tens):
 
-            downs_data = torch.nn.functional.interpolate(data_tens.float(),
-                                mode='bilinear',
-                                scale_factor=1/2,
-                                align_corners=False,
-                                **get_extra_interpolate_parameters())
+            downs_data = torch.nn.functional.interpolate(
+                data_tens.float(),
+                mode="bilinear",
+                scale_factor=1 / 2,
+                align_corners=False,
+                **get_extra_interpolate_parameters()
+            )
             return downs_data * 0.5
 
         return downsampler
 
     def get_upsampler(self):
         def upsampler(data_tens):
-            ups_data = torch.nn.functional.interpolate(data_tens.float(),
-                                mode='bilinear',
-                                scale_factor=2.0,
-                                align_corners=False,
-                                **get_extra_interpolate_parameters())
+            ups_data = torch.nn.functional.interpolate(
+                data_tens.float(),
+                mode="bilinear",
+                scale_factor=2.0,
+                align_corners=False,
+                **get_extra_interpolate_parameters()
+            )
             return ups_data * 2
 
         return upsampler
@@ -211,19 +243,20 @@ class FieldLayer(VolumetricLayer):
         return 2
 
     def get_default_data_type(self):
-        return 'float32'
+        return "float32"
 
 
 @register_layer_type("mask")
 class MaskLayer(VolumetricLayer):
-    def __init__(self, binarization=None,
-            num_channels=1, **kwargs):
+    def __init__(self, binarization=None, num_channels=1, **kwargs):
         self.binarizer = helpers.Binarizer(binarization)
         if num_channels != 1:
-            raise exceptions.ArgumentError("Mask layer 'num_channels'",
-                    "Mask layer must have 1 channels. 'num_channels' provided: {}".format(
-                        num_channels
-                        ))
+            raise exceptions.ArgumentError(
+                "Mask layer 'num_channels'",
+                "Mask layer must have 1 channels. 'num_channels' provided: {}".format(
+                    num_channels
+                ),
+            )
         super().__init__(**kwargs)
 
     def read(self, **kwargs):
@@ -234,21 +267,26 @@ class MaskLayer(VolumetricLayer):
     def get_downsampler(self):
         def downsampler(data_tens):
             return torch.nn.functional.max_pool2d(data_tens.float(), kernel_size=2)
+
         return downsampler
 
     def get_upsampler(self):
         def upsampler(data_tens):
-            return torch.nn.functional.interpolate(data_tens.float(),
-                    mode='nearest',
-                    scale_factor=2.0,
-                    **get_extra_interpolate_parameters())
+            return torch.nn.functional.interpolate(
+                data_tens.float(),
+                mode="nearest",
+                scale_factor=2.0,
+                **get_extra_interpolate_parameters()
+            )
+
         return upsampler
 
     def get_num_channels(self, *args, **kwargs):
         return 1
 
     def get_default_data_type(self):
-        return 'uint8'
+        return "uint8"
+
 
 @register_layer_type("section_value")
 class SectionValueLayer(VolumetricLayer):
@@ -263,10 +301,10 @@ class SectionValueLayer(VolumetricLayer):
 
     def indexing_scheme(self, bcube, mip, kwargs):
         new_bcube = copy.deepcopy(bcube)
-        if 'channel_start' in kwargs and 'channel_end' in kwargs:
-            channel_start = kwargs['channel_start']
-            channel_end = kwargs['channel_end']
-            del kwargs['channel_start'], kwargs['channel_end']
+        if "channel_start" in kwargs and "channel_end" in kwargs:
+            channel_start = kwargs["channel_start"]
+            channel_end = kwargs["channel_end"]
+            del kwargs["channel_start"], kwargs["channel_end"]
         else:
             channel_start = 0
             channel_end = self.num_channels
@@ -281,7 +319,8 @@ class SectionValueLayer(VolumetricLayer):
         return False
 
     def get_default_data_type(self):
-        return 'float32'
+        return "float32"
+
 
 @register_layer_type("fixed_field")
 class FixedFieldLayer(FieldLayer):
@@ -293,6 +332,7 @@ class FixedFieldLayer(FieldLayer):
     class. This class was intended to support existing fields created
     by legacy code. 
     """
+
     def __init__(self, *args, fixed_mip=0, **kwargs):
         super().__init__(*args, **kwargs)
         self.fixed_mip = fixed_mip
@@ -300,31 +340,35 @@ class FixedFieldLayer(FieldLayer):
     def get_downsampler(self):
         def downsampler(data_tens):
 
-            downs_data = torch.nn.functional.interpolate(data_tens.float(),
-                                mode='bilinear',
-                                scale_factor=1/2,
-                                align_corners=False,
-                                **get_extra_interpolate_parameters())
+            downs_data = torch.nn.functional.interpolate(
+                data_tens.float(),
+                mode="bilinear",
+                scale_factor=1 / 2,
+                align_corners=False,
+                **get_extra_interpolate_parameters()
+            )
             return downs_data
 
         return downsampler
 
     def get_upsampler(self):
         def upsampler(data_tens):
-            ups_data = torch.nn.functional.interpolate(data_tens.float(),
-                                mode='bilinear',
-                                scale_factor=2.0,
-                                align_corners=False,
-                                **get_extra_interpolate_parameters())
+            ups_data = torch.nn.functional.interpolate(
+                data_tens.float(),
+                mode="bilinear",
+                scale_factor=2.0,
+                align_corners=False,
+                **get_extra_interpolate_parameters()
+            )
             return ups_data
 
         return upsampler
 
     def read(self, bcube, mip, **kwargs):
-        return super().read(bcube, mip, **kwargs) / (2**(mip-self.fixed_mip))
+        return super().read(bcube, mip, **kwargs) / (2 ** (mip - self.fixed_mip))
 
     # def write(self, data_tens, bcube, mip, **kwargs):
-    #     super().write(data_tens=data_tens*(2**self.fixed_mip), 
-    #                   bcube=indexed_bcube, 
-    #                   mip=mip, 
+    #     super().write(data_tens=data_tens*(2**self.fixed_mip),
+    #                   bcube=indexed_bcube,
+    #                   mip=mip,
     #                   **kwargs)

--- a/corgie/layers/volumetric_layers.py
+++ b/corgie/layers/volumetric_layers.py
@@ -372,3 +372,41 @@ class FixedFieldLayer(FieldLayer):
     #                   bcube=indexed_bcube,
     #                   mip=mip,
     #                   **kwargs)
+
+
+@register_layer_type("float_tensor")
+class FloatTensorLayer(VolumetricLayer):
+    """Generic 4D float tensors"""
+    def __init__(self, *args, num_channels=1, **kwargs):
+        super().__init__(*args, **kwargs)
+        self.num_channels = num_channels
+
+    def get_downsampler(self):
+        def downsampler(data_tens):
+            return torch.nn.functional.interpolate(
+                data_tens.float(),
+                mode="bilinear",
+                scale_factor=1 / 2,
+                align_corners=False,
+                **get_extra_interpolate_parameters()
+            )
+
+        return downsampler
+
+    def get_upsampler(self):
+        def upsampler(data_tens):
+            return torch.nn.functional.interpolate(
+                data_tens.float(),
+                mode="bilinear",
+                scale_factor=2.0,
+                align_corners=False,
+                **get_extra_interpolate_parameters()
+            )
+
+        return upsampler
+
+    def get_num_channels(self, *args, **kwargs):
+        return self.num_channels
+
+    def get_default_data_type(self):
+        return "float32"


### PR DESCRIPTION
Add vote method to cli. Generalize VoteOverFields/VoteOverZ Jobs & Tasks with VoteJob/Task. Add FloatTensorLayer to write out intermediary weights. Requires [torchfields's voting-uncertainty branch](https://github.com/seung-lab/torchfields/tree/voting-uncertainty).